### PR TITLE
perf: do not import firebase in Login uiConfig

### DIFF
--- a/src/components/Login/uiConfig.ts
+++ b/src/components/Login/uiConfig.ts
@@ -1,5 +1,3 @@
-import firebase from 'firebase';
-
 /**
  * Configure FirebaseUI.
  *
@@ -10,8 +8,8 @@ const uiConfig = {
   signInFlow: 'popup',
   // Display auth providers.
   signInOptions: [
-    firebase.auth.GoogleAuthProvider.PROVIDER_ID,
-    firebase.auth.EmailAuthProvider.PROVIDER_ID,
+    'google.com', // require('firebase').auth.GoogleAuthProvider.PROVIDER_ID
+    'password', // require('firebase').auth.EmailAuthProvider.PROVIDER_ID
   ],
   callbacks: {
     // Avoid redirects after sign-in.


### PR DESCRIPTION
Decrease bundle size and resolve warning:

```
It looks like you're using the development build of the Firebase JS SDK.
When deploying Firebase apps to production, it is advisable to only
import
the individual SDK components you intend to use.

For the module builds, these are available in the following manner
(replace <PACKAGE> with the name of a component - i.e. auth, database,
etc):

CommonJS Modules:
const firebase = require('firebase/app');
require('firebase/<PACKAGE>');

ES Modules:
import firebase from 'firebase/app';
import 'firebase/<PACKAGE>';

Typescript:
import firebase from 'firebase/app';
import 'firebase/<PACKAGE>';
```

| File | Before | After |
| --- | --- | --- |
| *.chunk.js | 337 kB transferred over network, resource size: 1.5 MB | 239 kB transferred over network, resource size: 1 MB |
| main.*.chunk.js | 3.9 kB transferred over network, resource size: 15.7 kB | 3.9 kB transferred over network, resource size: 15.7 kB |
