### PR TITLE
fix(store): delete column itemIds when payload itemIds is empty

### DIFF
--- a/src/components/Columns/hooks/useColumns.test.tsx
+++ b/src/components/Columns/hooks/useColumns.test.tsx
@@ -160,9 +160,6 @@ describe('onChildChanged', () => {
         "column_test_id": Object {
           "createdAt": 1234567890,
           "createdBy": "user_test_id",
-          "itemIds": Array [
-            "item_test_id",
-          ],
           "name": "Column name2",
           "updatedAt": 1234567892,
           "updatedBy": "user_test_id2",

--- a/src/store/columnsSlice.test.ts
+++ b/src/store/columnsSlice.test.ts
@@ -37,7 +37,7 @@ describe('updateColumn', () => {
     expect(newState).toEqual({ [columnId]: column });
   });
 
-  it('edits column', () => {
+  it('updates column', () => {
     const state = {
       [columnId]: column,
     };
@@ -57,6 +57,51 @@ describe('updateColumn', () => {
         ...column,
         ...payload.column,
       },
+    });
+  });
+
+  it('replaces itemIds with payload itemIds', () => {
+    const state = {
+      [columnId]: {
+        ...column,
+        itemIds: ['foo', 'bar'],
+      },
+    };
+    const payload = {
+      boardId,
+      column: {
+        itemIds: [itemId],
+      },
+      columnId,
+      debounce: true,
+      skipSave: true,
+    };
+    const newState = reducer(state, actions.updateColumn(payload));
+    expect(newState).toEqual({
+      [columnId]: {
+        ...column,
+        ...payload.column,
+      },
+    });
+  });
+
+  it('deletes itemIds when itemIds is empty in payload', () => {
+    const state = {
+      [columnId]: {
+        ...column,
+        itemIds: [itemId],
+      },
+    };
+    const payload = {
+      boardId,
+      column: {},
+      columnId,
+      debounce: true,
+      skipSave: true,
+    };
+    const newState = reducer(state, actions.updateColumn(payload));
+    expect(newState).toEqual({
+      [columnId]: column,
     });
   });
 });

--- a/src/store/columnsSlice.ts
+++ b/src/store/columnsSlice.ts
@@ -32,6 +32,9 @@ const columnsSlice = createSlice({
       const { boardId, column, columnId, debounce, skipSave } = action.payload;
       state[columnId] = state[columnId] || {};
       Object.assign(state[columnId], column);
+      if (!column.itemIds) {
+        delete state[columnId].itemIds;
+      }
 
       if (!skipSave && boardId) {
         if (debounce) {


### PR DESCRIPTION
This fixes a bug when you drag an item from one column to another but the item persists in another view because Firebase on child changed listener returns null for empty array.

This causes the visual bug of duplicate item is 2 columns.