### PR TITLE
feat: add max likes

### DIFF
--- a/src/components/BoardControls/BoardControls.tsx
+++ b/src/components/BoardControls/BoardControls.tsx
@@ -2,6 +2,7 @@ import Box from '@mui/material/Box';
 
 import type { Id } from '../../types';
 import AddColumn from './AddColumn';
+import MaxLikes from './MaxLikes';
 import Present from './Present';
 import Sort from './Sort';
 import Timer from './Timer';
@@ -18,6 +19,8 @@ export default function BoardControls(props: Props) {
       </Box>
 
       <Timer boardId={props.boardId} />
+
+      <MaxLikes boardId={props.boardId} />
 
       <Present />
 

--- a/src/components/BoardControls/MaxLikes.test.tsx
+++ b/src/components/BoardControls/MaxLikes.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, screen } from '@testing-library/react';
+
+import { BOARD_TEST_ID as boardId } from '../../constants/test';
+import { logEvent } from '../../firebase';
+import { DEFAULT_MAX_LIKES } from '../../hooks';
+import { renderWithContext, updateStore } from '../../utils/test';
+import MaxLikes from './MaxLikes';
+
+jest.mock('../../firebase', () => ({
+  logEvent: jest.fn(),
+}));
+
+it('renders default max likes value', () => {
+  renderWithContext(<MaxLikes boardId={boardId} />);
+  expect(screen.getByRole('spinbutton', { name: 'Max Likes' })).toHaveValue(
+    DEFAULT_MAX_LIKES
+  );
+});
+
+describe('when user cannot edit', () => {
+  beforeEach(() => {
+    renderWithContext(<MaxLikes boardId={boardId} />);
+  });
+
+  it('renders disabled input', () => {
+    expect(screen.getByLabelText('Max Likes')).toBeDisabled();
+  });
+
+  it('does not change max likes value', () => {
+    const input = screen.getByLabelText('Max Likes');
+    const event = { target: { value: DEFAULT_MAX_LIKES + 1 } };
+    fireEvent.change(input, event);
+    expect(input).toHaveValue(DEFAULT_MAX_LIKES);
+    expect(logEvent).not.toBeCalled();
+  });
+});
+
+describe('when user can edit', () => {
+  let board: ReturnType<typeof updateStore.withBoard>;
+
+  beforeEach(() => {
+    board = updateStore.withBoard();
+    updateStore.withUser();
+    renderWithContext(<MaxLikes boardId={board.id} />);
+  });
+
+  it('changes max likes value', () => {
+    const input = screen.getByLabelText('Max Likes');
+    const event = { target: { value: '0' } };
+    fireEvent.change(input, event);
+    expect(input).toHaveValue(Number(event.target.value));
+  });
+
+  it('logs event', () => {
+    const input = screen.getByLabelText('Max Likes');
+    const event = { target: { value: '3.14' } };
+    fireEvent.change(input, event);
+    expect(logEvent).toBeCalledTimes(1);
+    expect(logEvent).toBeCalledWith('max_likes', {
+      boardId: board.id,
+      maxLikes: 3,
+    });
+  });
+});

--- a/src/components/BoardControls/MaxLikes.tsx
+++ b/src/components/BoardControls/MaxLikes.tsx
@@ -1,0 +1,56 @@
+import TextField from '@mui/material/TextField';
+import type { ChangeEvent } from 'react';
+
+import actions from '../../actions';
+import { logEvent } from '../../firebase';
+import { useDispatch, useMaxLikes, useSelector } from '../../hooks';
+import type { Id } from '../../types';
+
+interface Props {
+  boardId: Id;
+}
+
+export default function MaxLikes(props: Props) {
+  const { boardId } = props;
+
+  const dispatch = useDispatch();
+  const canEdit = useSelector(
+    (state) => (state.boards[boardId] || {}).createdBy === state.user.id
+  );
+  const maxLikes = useMaxLikes(boardId);
+
+  function handleChange(event: ChangeEvent<HTMLInputElement>) {
+    const newMaxLikes = Math.floor(Number(event.target.value));
+    if (canEdit && maxLikes !== newMaxLikes && newMaxLikes >= 0) {
+      dispatch(
+        actions.updateBoard({
+          boardId,
+          board: {
+            maxLikes: newMaxLikes,
+          },
+          debounce: true,
+        })
+      );
+      logEvent('max_likes', {
+        boardId,
+        maxLikes: newMaxLikes,
+      });
+    }
+  }
+
+  return (
+    <TextField
+      disabled={!canEdit}
+      inputProps={{
+        min: 0,
+        max: 1000,
+      }}
+      label="Max Likes"
+      onChange={handleChange}
+      size="small"
+      sx={{ marginRight: 2 }}
+      type="number"
+      value={maxLikes}
+    />
+  );
+}

--- a/src/components/Item/LikeButton.test.tsx
+++ b/src/components/Item/LikeButton.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, screen } from '@testing-library/react';
+
+import { renderWithContext, updateStore } from '../../utils/test';
+import LikeButton from './LikeButton';
+
+describe('when maxLikes is 0', () => {
+  beforeEach(() => {
+    const board = updateStore.withBoard({ maxLikes: 0 });
+    const item = updateStore.withItem();
+    renderWithContext(<LikeButton boardId={board.id} itemId={item.id} />);
+  });
+
+  it('does not like item', () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Like item' }));
+    expect(screen.getByLabelText('Like item')).toBeInTheDocument();
+  });
+});
+
+describe('when maxLikes is 1', () => {
+  beforeEach(() => {
+    const board = updateStore.withBoard({ maxLikes: 1 });
+    const item = updateStore.withItem();
+    renderWithContext(<LikeButton boardId={board.id} itemId={item.id} />);
+  });
+
+  it('likes item', () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Like item' }));
+    expect(screen.getByLabelText('Unlike item')).toBeInTheDocument();
+  });
+});

--- a/src/components/Item/LikeButton.tsx
+++ b/src/components/Item/LikeButton.tsx
@@ -37,7 +37,7 @@ export default function LikeButton(props: Props) {
   return (
     <IconButton
       size="small"
-      aria-label={`${isLikedByUser ? 'Unlike' : 'Like'} item "${props.itemId}"`}
+      aria-label={`${isLikedByUser ? 'Unlike' : 'Like'} item`}
       onClick={handleClick}
     >
       {isLikedByUser && !isUserPresenting ? (

--- a/src/components/Item/LikeButton.tsx
+++ b/src/components/Item/LikeButton.tsx
@@ -4,7 +4,7 @@ import IconButton from '@mui/material/IconButton';
 
 import actions from '../../actions';
 import { logEvent } from '../../firebase';
-import { useDispatch, useSelector } from '../../hooks';
+import { useDispatch, useMaxLikes, useSelector } from '../../hooks';
 import type { Id } from '../../types';
 
 interface Props {
@@ -16,8 +16,17 @@ export default function LikeButton(props: Props) {
   const dispatch = useDispatch();
   const userId = useSelector((state) => state.user.id);
   const likes = useSelector((state) => state.likes.items[props.itemId] || {});
-  const isUserPresenting = useSelector((state) => state.user.presenting);
   const isLikedByUser = likes[userId];
+  const totalLikes = useSelector((state) =>
+    Object.values(state.likes.items).reduce((accumulator, item) => {
+      if (item[userId]) {
+        accumulator++;
+      }
+      return accumulator;
+    }, 0)
+  );
+  const maxLikes = useMaxLikes(props.boardId);
+  const isUserPresenting = useSelector((state) => state.user.presenting);
 
   function handleClick() {
     const payload = {
@@ -28,7 +37,7 @@ export default function LikeButton(props: Props) {
     if (isLikedByUser) {
       dispatch(actions.unlikeItem(payload));
       logEvent('unlike_item');
-    } else {
+    } else if (totalLikes < maxLikes) {
       dispatch(actions.likeItem(payload));
       logEvent('like_item');
     }

--- a/src/components/Item/Likes.tsx
+++ b/src/components/Item/Likes.tsx
@@ -12,17 +12,21 @@ interface Props {
 
 export default function Likes(props: Props) {
   const likes = useSelector((state) => state.likes.items[props.itemId] || {});
-  const count = countObject(likes);
-  const label = `${count} ${count === 1 ? 'like' : 'likes'} for item "${
-    props.itemId
-  }"`;
+  const likesCount = countObject(likes);
 
   return (
     <>
       <LikeButton boardId={props.boardId} itemId={props.itemId} />
 
-      <Box aria-label={label} component="span" marginLeft={0.5} marginRight={1}>
-        {count}
+      <Box
+        aria-label={`${likesCount} ${
+          likesCount === 1 ? 'like' : 'likes'
+        } for item`}
+        component="span"
+        marginLeft={0.5}
+        marginRight={1}
+      >
+        {likesCount}
       </Box>
     </>
   );

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useAuth';
 export * from './useDispatch';
+export * from './useMaxLikes';
 export * from './useSelector';

--- a/src/hooks/useMaxLikes.test.ts
+++ b/src/hooks/useMaxLikes.test.ts
@@ -1,0 +1,91 @@
+import { BOARD_TEST_ID } from '../constants/test';
+import { useSelector } from '.';
+import { DEFAULT_MAX_LIKES, useMaxLikes } from './useMaxLikes';
+
+jest.mock('.', () => ({
+  useSelector: jest.fn(),
+}));
+
+describe('when boards are empty', () => {
+  const state = {
+    boards: {},
+  };
+
+  it('returns default max likes', () => {
+    (useSelector as jest.Mock).mockImplementationOnce((callback) =>
+      callback(state)
+    );
+    expect(useMaxLikes(BOARD_TEST_ID)).toBe(DEFAULT_MAX_LIKES);
+  });
+});
+
+describe('when board is undefined', () => {
+  const state = {
+    boards: {
+      [`${BOARD_TEST_ID}2`]: {
+        maxLikes: DEFAULT_MAX_LIKES - 1,
+      },
+    },
+  };
+
+  it('returns default max likes', () => {
+    (useSelector as jest.Mock).mockImplementationOnce((callback) =>
+      callback(state)
+    );
+    expect(useMaxLikes(BOARD_TEST_ID)).toBe(DEFAULT_MAX_LIKES);
+  });
+});
+
+describe('when maxLikes is undefined', () => {
+  const maxLikes = undefined;
+  const state = {
+    boards: {
+      [BOARD_TEST_ID]: {
+        maxLikes,
+      },
+    },
+  };
+
+  it('returns default max likes', () => {
+    (useSelector as jest.Mock).mockImplementationOnce((callback) =>
+      callback(state)
+    );
+    expect(useMaxLikes(BOARD_TEST_ID)).toBe(DEFAULT_MAX_LIKES);
+  });
+});
+
+describe('when maxLikes is valid', () => {
+  const maxLikes = DEFAULT_MAX_LIKES + 1;
+  const state = {
+    boards: {
+      [BOARD_TEST_ID]: {
+        maxLikes,
+      },
+    },
+  };
+
+  it('returns max likes', () => {
+    (useSelector as jest.Mock).mockImplementationOnce((callback) =>
+      callback(state)
+    );
+    expect(useMaxLikes(BOARD_TEST_ID)).toBe(maxLikes);
+  });
+});
+
+describe('when maxLikes is 0', () => {
+  const maxLikes = 0;
+  const state = {
+    boards: {
+      [BOARD_TEST_ID]: {
+        maxLikes,
+      },
+    },
+  };
+
+  it('returns 0', () => {
+    (useSelector as jest.Mock).mockImplementationOnce((callback) =>
+      callback(state)
+    );
+    expect(useMaxLikes(BOARD_TEST_ID)).toBe(maxLikes);
+  });
+});

--- a/src/hooks/useMaxLikes.ts
+++ b/src/hooks/useMaxLikes.ts
@@ -1,0 +1,16 @@
+import type { Id } from '../types';
+import { useSelector } from '.';
+
+export const DEFAULT_MAX_LIKES = 5;
+
+/**
+ * Max likes hook.
+ *
+ * @param boardId - Board id.
+ */
+export function useMaxLikes(boardId: Id): number {
+  const maxLikes = useSelector(
+    (state) => (state.boards[boardId] || {}).maxLikes
+  );
+  return maxLikes ?? DEFAULT_MAX_LIKES;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 export interface Board {
   createdAt: Time;
   createdBy: UserId;
+  maxLikes?: number;
   name: string;
   timerEnd?: number;
   updatedAt?: Time;

--- a/src/utils/test.tsx
+++ b/src/utils/test.tsx
@@ -19,7 +19,7 @@ import {
   USER_TEST_ID as userId,
 } from '../constants/test';
 import store from '../store';
-import type { Columns, Item, User } from '../types';
+import type { Board, Columns, Item, User } from '../types';
 
 /* istanbul ignore next */
 function noop() {}
@@ -48,19 +48,19 @@ export function resetStore() {
 }
 
 export const updateStore = {
-  withBoard() {
-    const board = {
-      createdAt: dateNow,
-      createdBy: userId,
-      name: 'Board One',
-    };
+  withBoard(board?: Partial<Board>) {
     const payload = {
-      board,
+      board: {
+        createdAt: dateNow,
+        createdBy: userId,
+        name: 'Board One',
+        ...board,
+      },
       boardId,
     };
     store.dispatch(actions.loadBoard(payload));
     return {
-      ...board,
+      ...payload.board,
       id: boardId,
     };
   },


### PR DESCRIPTION
# Requirements

- As a board creator, I can set max likes between `0` and `1000`.
   - When max likes is set to `0`, no one can like an item.
- Max likes default to `5`.
- As a user, I cannot like an item if my likes count is greater than max likes.
   - However, if the board creator decreased max likes, user likes will not be removed so there can technically be more likes than max likes.
   - There is no restriction to unliking an item.