### PR TITLE
fix: don't save board to database if user is not admin

### DIFF
--- a/src/components/BoardControls/Timer.tsx
+++ b/src/components/BoardControls/Timer.tsx
@@ -24,7 +24,7 @@ export default function Timer(props: Props) {
   const { boardId } = props;
 
   const dispatch = useDispatch();
-  const canEdit = useIsAdmin(boardId);
+  const isAdmin = useIsAdmin(boardId);
   const timerEnd = useSelector(
     (state) => (state.boards[boardId] || {}).timerEnd
   );
@@ -36,6 +36,7 @@ export default function Timer(props: Props) {
       minutes: state.minutes,
       value: String(state.minutes),
     });
+
     setTimeout(() => {
       dispatch(
         actions.updateBoard({
@@ -43,10 +44,11 @@ export default function Timer(props: Props) {
           board: {
             timerEnd: 0,
           },
+          skipSave: !isAdmin,
         })
       );
     });
-  }, [dispatch, boardId, setState, state.minutes]);
+  }, [boardId, dispatch, isAdmin, setState, state.minutes]);
 
   useEffect(() => {
     if (!timerEnd) {
@@ -82,7 +84,7 @@ export default function Timer(props: Props) {
   }
 
   function startTimer() {
-    if (canEdit && state.minutes > 0) {
+    if (isAdmin && state.minutes > 0) {
       loadAlarm();
       dispatch(
         actions.updateBoard({
@@ -95,7 +97,7 @@ export default function Timer(props: Props) {
     }
   }
 
-  if (!canEdit && !timerEnd) {
+  if (!isAdmin && !timerEnd) {
     return null;
   }
 
@@ -117,7 +119,7 @@ export default function Timer(props: Props) {
         value={state.value}
       />
 
-      {canEdit && (
+      {isAdmin && (
         <Button
           aria-label={timerEnd ? 'Stop timer' : 'Start timer'}
           onClick={timerEnd ? stopTimer : startTimer}

--- a/src/store/boardsSlice.test.ts
+++ b/src/store/boardsSlice.test.ts
@@ -34,16 +34,37 @@ describe('updateBoard', () => {
     });
   });
 
-  it('edits board', () => {
+  it('updates board', () => {
     const state = {
       [boardId]: board,
     };
     const payload = {
       board: {
-        name: 'Board Name Edited',
+        name: 'Board Name Updated',
         updatedAt: Date.now() + 1000,
       },
       boardId,
+    };
+    const newState = reducer(state, actions.updateBoard(payload));
+    expect(newState).toEqual({
+      [boardId]: {
+        ...state[boardId],
+        ...payload.board,
+      },
+    });
+  });
+
+  it('updates board when skipSave is true', () => {
+    const state = {
+      [boardId]: board,
+    };
+    const payload = {
+      board: {
+        name: 'Board Name Updated',
+        updatedAt: Date.now() + 1000,
+      },
+      boardId,
+      skipSave: true,
     };
     const newState = reducer(state, actions.updateBoard(payload));
     expect(newState).toEqual({

--- a/src/store/boardsSlice.ts
+++ b/src/store/boardsSlice.ts
@@ -25,15 +25,20 @@ const boardsSlice = createSlice({
         board: Partial<Board>;
         boardId: Id;
         debounce?: boolean;
+        skipSave?: boolean;
       }>
     ) => {
-      const { board, boardId, debounce } = action.payload;
+      const { board, boardId, debounce, skipSave } = action.payload;
       state[boardId] = state[boardId] || {};
       Object.assign(state[boardId], board);
-      if (debounce) {
-        debouncedSaveBoardData(boardId, board);
-      } else {
-        saveBoardData(boardId, board);
+      const saveToDatabase = !skipSave;
+
+      if (saveToDatabase) {
+        if (debounce) {
+          debouncedSaveBoardData(boardId, board);
+        } else {
+          saveBoardData(boardId, board);
+        }
       }
     },
 


### PR DESCRIPTION
## Steps to Reproduce

1. Start timer as a non-admin user
2. Open up the browser console and see that at the end of the timer, it tries to update Firebase database
3. See warning

# Expected

When board timer ends, no warning about non-admin user trying to update board.

## Actual

When board timer ends, warning about non-admin user trying to update board.