### PR TITLE
fix(utils): replace newline with <br> when exporting board to markdown

### DIFF
--- a/src/components/BoardControls/utils/transform.test.ts
+++ b/src/components/BoardControls/utils/transform.test.ts
@@ -211,6 +211,34 @@ describe('transformToMarkdown', () => {
     `);
   });
 
+  it('transforms column with item with newlines', () => {
+    expect(
+      transformToMarkdown(
+        {
+          column1: {
+            createdAt: Date.now(),
+            createdBy: 'user1',
+            itemIds: ['item1'],
+            name: 'Column Name',
+          },
+        },
+
+        {
+          item1: {
+            createdAt: Date.now(),
+            createdBy: 'user1',
+            text: 'Item\n\n1',
+          },
+        }
+      )
+    ).toMatchInlineSnapshot(`
+      "| Column Name |
+      | --- |
+      | Item<br><br>1 |
+      "
+    `);
+  });
+
   it('transforms column with items', () => {
     expect(
       transformToMarkdown(

--- a/src/components/BoardControls/utils/transform.ts
+++ b/src/components/BoardControls/utils/transform.ts
@@ -46,7 +46,11 @@ export function transformToMarkdown(columns: Columns, items: Items): string {
   markdown += '\n';
 
   rows.forEach((row) => {
-    markdown += `| ${row.join(' | ')} |`;
+    markdown += `| ${row
+      .map((text) =>
+        typeof text === 'string' ? text.replaceAll('\n', '<br>') : text
+      )
+      .join(' | ')} |`;
     markdown += '\n';
   });
 


### PR DESCRIPTION
Fix bug when there's newlines in Markdown table when board is exported

Steps to Reproduce:

1. Create a board
2. Create a column
3. Create an item and add text with newlines
4. Click `Export`
5. Paste and see newlines in Markdown table when there shouldn't be any