### PR TITLE
fix: don't make column items temporarily disappear during rename

### DIFF
--- a/src/components/Column/ColumnName.tsx
+++ b/src/components/Column/ColumnName.tsx
@@ -41,15 +41,12 @@ export default function ColumnName(props: Props) {
     event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) {
     dispatch(
-      actions.updateColumn({
+      actions.renameColumn({
         boardId: props.boardId,
-        column: {
-          name: event.target.value,
-          updatedAt: Date.now(),
-          updatedBy: userId,
-        },
         columnId: props.columnId,
+        columnName: event.target.value,
         debounce: true,
+        userId,
       })
     );
   }

--- a/src/store/columnsSlice.test.ts
+++ b/src/store/columnsSlice.test.ts
@@ -34,22 +34,23 @@ describe('updateColumn', () => {
       columnId,
     };
     const newState = reducer(initialState, actions.updateColumn(payload));
-    expect(newState).toEqual({ [columnId]: column });
+    expect(newState).toEqual({
+      [columnId]: column,
+    });
   });
 
-  it('updates column', () => {
+  it.each([true, false])('updates column with debounce=%p', (debounce) => {
     const state = {
       [columnId]: column,
     };
     const payload = {
       boardId,
       column: {
-        name: 'Column Name Edited',
+        name: 'Edited Column',
         updatedAt: Date.now() + 1000,
       },
       columnId,
       debounce: true,
-      skipSave: true,
     };
     const newState = reducer(state, actions.updateColumn(payload));
     expect(newState).toEqual({
@@ -102,6 +103,46 @@ describe('updateColumn', () => {
     const newState = reducer(state, actions.updateColumn(payload));
     expect(newState).toEqual({
       [columnId]: column,
+    });
+  });
+});
+
+describe('renameColumn', () => {
+  it('sets column name', () => {
+    const payload = {
+      boardId,
+      columnId,
+      columnName: 'New Column',
+      userId,
+    };
+    const newState = reducer(initialState, actions.renameColumn(payload));
+    expect(newState).toEqual({
+      [columnId]: {
+        name: payload.columnName,
+        updatedAt: expect.any(Number),
+        updatedBy: payload.userId,
+      },
+    });
+  });
+
+  it.each([true, false])('updates column name with debounce=%p', (debounce) => {
+    const state = {
+      [columnId]: column,
+    };
+    const payload = {
+      boardId,
+      columnId,
+      columnName: 'Updated Column',
+      debounce,
+      userId: `${userId}_2`,
+    };
+    expect(reducer(state, actions.renameColumn(payload))).toEqual({
+      [columnId]: {
+        ...column,
+        name: payload.columnName,
+        updatedAt: expect.any(Number),
+        updatedBy: payload.userId,
+      },
     });
   });
 });

--- a/src/store/columnsSlice.ts
+++ b/src/store/columnsSlice.ts
@@ -32,6 +32,7 @@ const columnsSlice = createSlice({
       const { boardId, column, columnId, debounce, skipSave } = action.payload;
       state[columnId] = state[columnId] || {};
       Object.assign(state[columnId], column);
+
       if (!column.itemIds) {
         delete state[columnId].itemIds;
       }
@@ -42,6 +43,33 @@ const columnsSlice = createSlice({
         } else {
           updateColumn(boardId, columnId, column);
         }
+      }
+    },
+
+    renameColumn: (
+      state,
+      action: PayloadAction<{
+        boardId: Id;
+        columnId: Id;
+        columnName: Column['name'];
+        debounce?: boolean;
+        userId: Column['updatedBy'];
+      }>
+    ) => {
+      const { boardId, columnId, columnName, debounce, userId } =
+        action.payload;
+      state[columnId] = state[columnId] || {};
+      const column = {
+        name: columnName,
+        updatedAt: Date.now(),
+        updatedBy: userId,
+      };
+      Object.assign(state[columnId], column);
+
+      if (debounce) {
+        debouncedUpdateColumn(boardId, columnId, column);
+      } else {
+        updateColumn(boardId, columnId, column);
       }
     },
 


### PR DESCRIPTION
# Steps to Reproduce

1. Login
2. Create board
3. Create column
4. Create item
5. Rename column

# Expected Behavior

Items don't temporarily disappear on column rename

# Actual Behavior

Items temporarily disappear on column rename