### PR TITLE
feat(components): update Export icon and improve copy and margin

### DIFF
--- a/src/components/BoardControls/Export.tsx
+++ b/src/components/BoardControls/Export.tsx
@@ -1,4 +1,4 @@
-import CopyIcon from '@mui/icons-material/ContentCopy';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 
@@ -19,7 +19,7 @@ export default function Export() {
   return (
     <Tooltip arrow title="Copy board as Markdown">
       <IconButton color="info" onClick={copyBoardMarkdownToClipboard}>
-        <CopyIcon />
+        <FileDownloadIcon />
       </IconButton>
     </Tooltip>
   );

--- a/src/components/BoardControls/Sort.tsx
+++ b/src/components/BoardControls/Sort.tsx
@@ -38,7 +38,7 @@ export default function Sort(props: Props) {
       color="primary"
       onClick={sortItems}
       variant="outlined"
-      sx={{ marginRight: 2 }}
+      sx={{ marginRight: 1 }}
     >
       Sort by likes
     </Button>

--- a/src/pages/Board/BoardName.test.tsx
+++ b/src/pages/Board/BoardName.test.tsx
@@ -35,7 +35,7 @@ it('renders board name', () => {
 
 it('copies board link to clipboard', () => {
   render(<BoardName name={boardName} />);
-  fireEvent.click(screen.getByLabelText('Copy link to board'));
+  fireEvent.click(screen.getByLabelText('Copy board link'));
   expect(writeText).toBeCalledTimes(1);
   expect(writeText).toBeCalledWith(window.location.href);
 });

--- a/src/pages/Board/BoardName.tsx
+++ b/src/pages/Board/BoardName.tsx
@@ -18,12 +18,7 @@ export default function BoardName(props: Props) {
     <Typography component="h1" gutterBottom variant="h4">
       {props.name}
 
-      <Tooltip
-        arrow
-        placement="right"
-        sx={{ marginLeft: 1 }}
-        title="Copy link to board"
-      >
+      <Tooltip arrow placement="right" title="Copy board link">
         <IconButton color="info" onClick={copyBoardLinkToClipboard}>
           <LinkIcon />
         </IconButton>


### PR DESCRIPTION
Icon: https://mui.com/material-ui/material-icons/?query=export&selected=FileDownload

# Before

<img width="1157" alt="Screen Shot 2022-11-13 at 1 54 08 PM" src="https://user-images.githubusercontent.com/10594555/201539091-99f90d25-c371-47d1-8bc7-d88f04f5634a.png">

# After

<img width="1154" alt="Screen Shot 2022-11-13 at 1 53 10 PM" src="https://user-images.githubusercontent.com/10594555/201539090-aff6fa0a-99d6-45c6-9537-7676299e7625.png">