### PR TITLE
feat(pages): render breadcrumbs in Board

### DIFF
--- a/src/pages/Board/Board.test.tsx
+++ b/src/pages/Board/Board.test.tsx
@@ -66,27 +66,48 @@ it('redirects to "/404" when board is not found', async () => {
   await waitFor(() => expect(router.state.location.pathname).toBe('/404'));
 });
 
-it('renders board name as heading', async () => {
-  const board = updateStore.withBoard();
-  mockedUseParams.mockReturnValue({ boardId: board.id });
-  renderWithContext(<Board />);
-  expect(await screen.findByRole('heading', { level: 1 })).toBe(
-    await screen.findByText(board.name)
-  );
+describe('breadcrumbs', () => {
+  it('renders boards link', () => {
+    const board = updateStore.withBoard();
+    mockedUseParams.mockReturnValue({ boardId: board.id });
+    renderWithContext(<Board />);
+    expect(screen.getByRole('link', { name: 'Boards' })).toHaveAttribute(
+      'href',
+      '/boards'
+    );
+  });
 });
 
-it('renders <BoardControls>', async () => {
-  const board = updateStore.withBoard();
-  mockedUseParams.mockReturnValue({ boardId: board.id });
-  renderWithContext(<Board />);
-  expect(await screen.findByText(boardControls)).toBeInTheDocument();
+describe('board name', () => {
+  it('does not render board name as heading', () => {
+    const board = updateStore.withBoard({ name: '' });
+    mockedUseParams.mockReturnValue({ boardId: board.id });
+    renderWithContext(<Board />);
+    expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
+  });
+
+  it('renders board name as heading', () => {
+    const board = updateStore.withBoard();
+    mockedUseParams.mockReturnValue({ boardId: board.id });
+    renderWithContext(<Board />);
+    expect(screen.getByRole('heading', { level: 1 })).toBe(
+      screen.getByText(board.name)
+    );
+  });
 });
 
-it('renders <Columns>', async () => {
+it('renders <BoardControls>', () => {
   const board = updateStore.withBoard();
   mockedUseParams.mockReturnValue({ boardId: board.id });
   renderWithContext(<Board />);
-  expect(await screen.findByText(columns)).toBeInTheDocument();
+  expect(screen.getByText(boardControls)).toBeInTheDocument();
+});
+
+it('renders <Columns>', () => {
+  const board = updateStore.withBoard();
+  mockedUseParams.mockReturnValue({ boardId: board.id });
+  renderWithContext(<Board />);
+  expect(screen.getByText(columns)).toBeInTheDocument();
 });
 
 describe('with board and anonymous user', () => {

--- a/src/pages/Board/Board.tsx
+++ b/src/pages/Board/Board.tsx
@@ -1,5 +1,8 @@
+import Breadcrumbs from '@mui/material/Breadcrumbs';
+import Link from '@mui/material/Link';
 import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
 
 import BoardControls from '../../components/BoardControls';
 import Columns from '../../components/Columns';
@@ -39,8 +42,21 @@ export default function Board() {
 
   return (
     <>
-      <BoardName name={board.name} />
+      <Breadcrumbs aria-label="breadcrumb">
+        <Link
+          color="inherit"
+          component={RouterLink}
+          to="/boards"
+          underline="hover"
+        >
+          Boards
+        </Link>
+      </Breadcrumbs>
+
+      {board.name ? <BoardName name={board.name} /> : <br />}
+
       <BoardControls boardId={boardId} />
+
       <Columns boardId={boardId} />
     </>
   );

--- a/src/pages/Board/BoardName.test.tsx
+++ b/src/pages/Board/BoardName.test.tsx
@@ -20,13 +20,12 @@ afterAll(() => {
   jest.useRealTimers();
 });
 
-it('renders nothing when there is no name', () => {
-  render(<BoardName />);
-  expect(screen.queryAllByRole('heading')).toHaveLength(0);
-});
+const props = {
+  name: boardName,
+};
 
 it('renders board name', () => {
-  render(<BoardName name={boardName} />);
+  render(<BoardName {...props} />);
   expect(screen.getByText(boardName)).toBeInTheDocument();
   expect(screen.getByRole('heading', { level: 1 })).toBe(
     screen.getByText(boardName)
@@ -34,7 +33,7 @@ it('renders board name', () => {
 });
 
 it('copies board link to clipboard', () => {
-  render(<BoardName name={boardName} />);
+  render(<BoardName {...props} />);
   fireEvent.click(screen.getByLabelText('Copy board link'));
   expect(writeText).toBeCalledTimes(1);
   expect(writeText).toBeCalledWith(window.location.href);

--- a/src/pages/Board/BoardName.tsx
+++ b/src/pages/Board/BoardName.tsx
@@ -6,14 +6,10 @@ import Typography from '@mui/material/Typography';
 import { logEvent } from '../../firebase';
 
 interface Props {
-  name?: string;
+  name: string;
 }
 
 export default function BoardName(props: Props) {
-  if (!props.name) {
-    return null;
-  }
-
   return (
     <Typography component="h1" gutterBottom variant="h4">
       {props.name}


### PR DESCRIPTION
<img width="208" alt="Screen Shot 2022-11-13 at 4 37 59 PM" src="https://user-images.githubusercontent.com/10594555/201545840-780ca5a3-a41f-429c-b3c2-68b2e0ede3d3.png">

<img width="161" alt="Screen Shot 2022-11-13 at 4 38 18 PM" src="https://user-images.githubusercontent.com/10594555/201545843-1be111cd-e791-4882-89b8-47c845cc2dbd.png">
