### PR TITLE
fix(components): fix margins of BoardControls

### DIFF
--- a/src/components/BoardControls/Export.tsx
+++ b/src/components/BoardControls/Export.tsx
@@ -18,7 +18,11 @@ export default function Export() {
 
   return (
     <Tooltip arrow title="Copy board as Markdown">
-      <IconButton color="info" onClick={copyBoardMarkdownToClipboard}>
+      <IconButton
+        color="info"
+        onClick={copyBoardMarkdownToClipboard}
+        sx={{ marginLeft: 0.5 }}
+      >
         <FileDownloadIcon />
       </IconButton>
     </Tooltip>

--- a/src/components/BoardControls/Present.tsx
+++ b/src/components/BoardControls/Present.tsx
@@ -22,6 +22,7 @@ export default function Present() {
         <Switch checked={presenting} color="primary" onChange={handleChange} />
       }
       label="Hide Likes"
+      sx={{ marginRight: 0 }}
     />
   );
 }

--- a/src/components/BoardControls/Sort.tsx
+++ b/src/components/BoardControls/Sort.tsx
@@ -38,7 +38,7 @@ export default function Sort(props: Props) {
       color="primary"
       onClick={sortItems}
       variant="outlined"
-      sx={{ marginRight: 1 }}
+      sx={{ marginLeft: 2 }}
     >
       Sort by likes
     </Button>


### PR DESCRIPTION
# Before

Owner:

<img width="602" alt="Screen Shot 2022-11-14 at 12 44 35 AM" src="https://user-images.githubusercontent.com/10594555/201584493-7f3dbe51-d854-49b8-bfa1-64db70284e77.png">

Non-owner:

<img width="280" alt="Screen Shot 2022-11-14 at 12 44 52 AM" src="https://user-images.githubusercontent.com/10594555/201584494-564def7c-5f69-44aa-91fd-8afe46c7e1a3.png">

# After

Owner:

<img width="599" alt="Screen Shot 2022-11-14 at 12 43 33 AM" src="https://user-images.githubusercontent.com/10594555/201584492-f5e525e0-6edd-4fb2-96da-0d788dad7231.png">

Non-owner:

<img width="268" alt="Screen Shot 2022-11-14 at 12 43 13 AM" src="https://user-images.githubusercontent.com/10594555/201584490-3757877a-4b5a-4f76-b048-30d074e279a2.png">