### PR TITLE
fix(store): delete board from store when firebase value is null

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -2,9 +2,11 @@
   "rules": {
     "boards": {
       "$board_id": {
+        ".write": "auth.uid !== null && auth.token.email_verified === true",
+
         "board": {
           ".read": "auth.uid !== null",
-          ".write": "auth.token.email_verified === true"
+          ".write": "auth.uid !== null && auth.token.email_verified === true"
         },
 
         "columns": {

--- a/src/pages/Board/hooks/useBoard.ts
+++ b/src/pages/Board/hooks/useBoard.ts
@@ -21,6 +21,7 @@ export function useBoard(boardId: Id) {
       getBoardDataRef(boardId),
       (boardSnapshot) => {
         const board = boardSnapshot.val();
+
         if (board) {
           // prevent race condition with redux reducer
           setTimeout(() => {
@@ -33,6 +34,14 @@ export function useBoard(boardId: Id) {
             setIsLoaded(true);
           });
         } else {
+          // board removed
+          dispatch(
+            actions.deleteBoard({
+              boardId,
+              skipSave: true,
+              userId: '',
+            })
+          );
           setIsLoaded(true);
         }
       }

--- a/src/store/boardsSlice.test.ts
+++ b/src/store/boardsSlice.test.ts
@@ -84,6 +84,14 @@ describe('deleteBoard', () => {
     const payload = { boardId, userId };
     expect(reducer(state, actions.deleteBoard(payload))).toEqual({});
   });
+
+  it('deletes board when skipSave is true', () => {
+    const state = {
+      [boardId]: board,
+    };
+    const payload = { boardId, userId, skipSave: true };
+    expect(reducer(state, actions.deleteBoard(payload))).toEqual({});
+  });
 });
 
 describe('loadBoard', () => {

--- a/src/store/boardsSlice.ts
+++ b/src/store/boardsSlice.ts
@@ -31,9 +31,8 @@ const boardsSlice = createSlice({
       const { board, boardId, debounce, skipSave } = action.payload;
       state[boardId] = state[boardId] || {};
       Object.assign(state[boardId], board);
-      const saveToDatabase = !skipSave;
 
-      if (saveToDatabase) {
+      if (!skipSave) {
         if (debounce) {
           debouncedSaveBoardData(boardId, board);
         } else {
@@ -44,12 +43,14 @@ const boardsSlice = createSlice({
 
     deleteBoard: (
       state,
-      action: PayloadAction<{ boardId: Id; userId: Id }>
+      action: PayloadAction<{ boardId: Id; userId: Id; skipSave?: boolean }>
     ) => {
-      const { boardId, userId } = action.payload;
-      removeBoard(boardId);
-      removeUserBoard(userId, boardId);
+      const { boardId, skipSave, userId } = action.payload;
       delete state[boardId];
+      if (!skipSave) {
+        removeBoard(boardId);
+        removeUserBoard(userId, boardId);
+      }
     },
 
     loadBoard: (


### PR DESCRIPTION
> **Update**: it turned out to be a regression caused by changes made to `database.rules.json`

## Steps to Reproduce

1. Create a board and copy board link
2. Open board link in another session (incognito browser)
3. Delete board
4. See that board persists in the other session and can still be updated

## Expected Result

Board is gone and can no longer be updated and user is redirected to 404 page

## Actual Result

Board persists and can be updated by user