### PR TITLE
feat(pages): add Support page

### DIFF
--- a/cypress/e2e/support/support.feature
+++ b/cypress/e2e/support/support.feature
@@ -1,0 +1,16 @@
+Feature: Support
+  Scenario: Support link in header
+    Given I visit "/"
+    Then I see label "Support"
+    When I click on label "Support"
+    Then I see URL "/support"
+
+  Scenario: Support page
+    Given I visit "/support"
+    Then I see link "issue"
+      And I see link "discussion"
+      And I see link "GitHub Sponsors"
+      And I see link "Patreon"
+      And I see link "Ko-fi"
+      And I see link "Liberapay"
+      And I see link "Teespring"

--- a/src/components/Layout/Header.test.tsx
+++ b/src/components/Layout/Header.test.tsx
@@ -16,6 +16,11 @@ it('renders heading link', () => {
   );
 });
 
+it('renders support link', () => {
+  renderWithContext(<Header />);
+  expect(screen.getByLabelText('Support')).toHaveAttribute('href', '/support');
+});
+
 it('renders GitHub link', () => {
   renderWithContext(<Header />);
   expect(screen.getByLabelText('Open GitHub repository')).toHaveAttribute(

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -37,6 +37,7 @@ export default function Header() {
             color="inherit"
             component={RouterLink}
             to="/support"
+            title="Support"
           >
             <SupportIcon />
           </IconButton>
@@ -48,6 +49,7 @@ export default function Header() {
             href="https://b.remarkabl.org/lilboards"
             target="_blank"
             rel="noopener noreferrer"
+            title="GitHub"
           >
             <GitHubIcon />
           </Link>

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -1,4 +1,5 @@
 import GitHubIcon from '@mui/icons-material/GitHub';
+import SupportIcon from '@mui/icons-material/Support';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -30,6 +31,15 @@ export default function Header() {
               Lilboards
             </Link>
           </Box>
+
+          <IconButton
+            aria-label="Support"
+            color="inherit"
+            component={RouterLink}
+            to="/support"
+          >
+            <SupportIcon />
+          </IconButton>
 
           <Link
             aria-label="Open GitHub repository"

--- a/src/pages/Support/Support.test.tsx
+++ b/src/pages/Support/Support.test.tsx
@@ -1,0 +1,48 @@
+import { screen } from '@testing-library/react';
+
+import { renderWithContext } from '../../utils/test';
+import { sponsorLinks } from './constants';
+import Support from './Support';
+
+it('renders heading', () => {
+  renderWithContext(<Support />);
+  expect(
+    screen.getByRole('heading', {
+      level: 1,
+      name: 'Support',
+    })
+  ).toBeInTheDocument();
+});
+
+it('renders GitHub issue link', () => {
+  renderWithContext(<Support />);
+  expect(
+    screen.getByRole('link', {
+      name: 'issue',
+    })
+  ).toHaveAttribute(
+    'href',
+    'https://github.com/lilboards/lilboards/issues/new/choose'
+  );
+});
+
+it('renders GitHub discussion link', () => {
+  renderWithContext(<Support />);
+  expect(
+    screen.getByRole('link', {
+      name: 'discussion',
+    })
+  ).toHaveAttribute(
+    'href',
+    'https://github.com/lilboards/lilboards/discussions/new/choose'
+  );
+});
+
+it.each(sponsorLinks)('renders sponsor link "$text"', ({ text, href }) => {
+  renderWithContext(<Support />);
+  expect(
+    screen.getByRole('link', {
+      name: text,
+    })
+  ).toHaveAttribute('href', href);
+});

--- a/src/pages/Support/Support.test.tsx
+++ b/src/pages/Support/Support.test.tsx
@@ -20,10 +20,7 @@ it('renders GitHub issue link', () => {
     screen.getByRole('link', {
       name: 'issue',
     })
-  ).toHaveAttribute(
-    'href',
-    'https://github.com/lilboards/lilboards/issues/new/choose'
-  );
+  ).toHaveAttribute('href', 'https://github.com/lilboards/lilboards/issues');
 });
 
 it('renders GitHub discussion link', () => {
@@ -34,7 +31,7 @@ it('renders GitHub discussion link', () => {
     })
   ).toHaveAttribute(
     'href',
-    'https://github.com/lilboards/lilboards/discussions/new/choose'
+    'https://github.com/lilboards/lilboards/discussions'
   );
 });
 

--- a/src/pages/Support/Support.tsx
+++ b/src/pages/Support/Support.tsx
@@ -1,0 +1,50 @@
+import Link from '@mui/material/Link';
+import Typography from '@mui/material/Typography';
+
+import { useSetDocumentTitle } from '../../hooks';
+import { sponsorLinks } from './constants';
+
+export default function Support() {
+  useSetDocumentTitle('Support');
+
+  return (
+    <>
+      <Typography component="h1" paragraph variant="h4">
+        Support
+      </Typography>
+
+      <Typography paragraph>
+        Have a question? Open an{' '}
+        <Link
+          href="https://github.com/lilboards/lilboards/issues/new/choose"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          issue
+        </Link>{' '}
+        or{' '}
+        <Link
+          href="https://github.com/lilboards/lilboards/discussions/new/choose"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          discussion
+        </Link>
+        .
+      </Typography>
+
+      <Typography paragraph component="section">
+        Want to sponsor this project?
+        <ul>
+          {sponsorLinks.map(({ text, href }, index) => (
+            <li key={index}>
+              <Link href={href} target="_blank" rel="noopener noreferrer">
+                {text}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </Typography>
+    </>
+  );
+}

--- a/src/pages/Support/Support.tsx
+++ b/src/pages/Support/Support.tsx
@@ -16,7 +16,7 @@ export default function Support() {
       <Typography paragraph>
         Have a question? Open an{' '}
         <Link
-          href="https://github.com/lilboards/lilboards/issues/new/choose"
+          href="https://github.com/lilboards/lilboards/issues"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -24,7 +24,7 @@ export default function Support() {
         </Link>{' '}
         or{' '}
         <Link
-          href="https://github.com/lilboards/lilboards/discussions/new/choose"
+          href="https://github.com/lilboards/lilboards/discussions"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/src/pages/Support/constants.ts
+++ b/src/pages/Support/constants.ts
@@ -1,0 +1,22 @@
+export const sponsorLinks = [
+  {
+    text: 'GitHub Sponsors',
+    href: 'https://b.remarkabl.org/github-sponsors',
+  },
+  {
+    text: 'Patreon',
+    href: 'https://b.remarkabl.org/patreon',
+  },
+  {
+    text: 'Ko-fi',
+    href: 'https://b.remarkabl.org/ko-fi',
+  },
+  {
+    text: 'Liberapay',
+    href: 'https://b.remarkabl.org/liberapay',
+  },
+  {
+    text: 'Teespring',
+    href: 'https://b.remarkabl.org/teespring',
+  },
+] as const;

--- a/src/pages/Support/index.test.tsx
+++ b/src/pages/Support/index.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen, waitFor } from '@testing-library/react';
+
+import SupportLoader from '.';
+
+jest.mock('./Support', () => () => <>Support</>);
+
+it('lazy loads Support', async () => {
+  render(<SupportLoader />);
+  expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+  expect(screen.getByText('Support')).toBeInTheDocument();
+});

--- a/src/pages/Support/index.tsx
+++ b/src/pages/Support/index.tsx
@@ -1,0 +1,12 @@
+import CircularProgress from '@mui/material/CircularProgress';
+import { lazy, Suspense } from 'react';
+
+const Support = lazy(() => import('./Support'));
+
+export default function SupportLoader() {
+  return (
+    <Suspense fallback={<CircularProgress />}>
+      <Support />
+    </Suspense>
+  );
+}

--- a/src/routes/index.test.tsx
+++ b/src/routes/index.test.tsx
@@ -19,6 +19,10 @@ it('matches snapshot', () => {
         path="logout"
       />
       <Route
+        element={<SupportLoader />}
+        path="support"
+      />
+      <Route
         path="boards"
       >
         <Route

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -9,6 +9,7 @@ import Home from '../pages/Home';
 import Login from '../pages/Login';
 import Logout from '../pages/Logout';
 import NotFound from '../pages/NotFound';
+import Support from '../pages/Support';
 
 const routes: ReactElement = (
   <Route path="/" element={<Layout />}>
@@ -16,6 +17,7 @@ const routes: ReactElement = (
 
     <Route path="login" element={<Login />} />
     <Route path="logout" element={<Logout />} />
+    <Route path="support" element={<Support />} />
 
     <Route path="boards">
       <Route element={<Protected check="email" />}>


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(pages): add Support

## What is the current behavior?

No support page

## What is the new behavior?

Support page (`/support`) renders links to GitHub issues + discussions and sponsors

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests