### PR TITLE
feat: display error message when Firebase Realtime Database is disconnected

### DIFF
--- a/src/components/Connection/Connection.test.tsx
+++ b/src/components/Connection/Connection.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { onConnected } from '../../firebase/database';
+import Connection from './Connection';
+
+jest.mock('../../firebase/database', () => ({
+  onConnected: jest.fn(),
+}));
+
+const mockedOnConnected = jest.mocked(onConnected);
+
+const message = 'Unable to connect to server. Realtime updates are paused.';
+
+describe('connected', () => {
+  beforeEach(() => {
+    const isConnected = true;
+    mockedOnConnected.mockImplementation((callback) => {
+      callback(isConnected);
+    });
+  });
+
+  it('does not render error', () => {
+    render(<Connection />);
+    expect(screen.queryByText(message)).not.toBeInTheDocument();
+  });
+});
+
+describe('disconnected', () => {
+  beforeEach(() => {
+    const isConnected = false;
+    mockedOnConnected.mockImplementation((callback) => {
+      callback(isConnected);
+    });
+  });
+
+  it('renders error when disconnected', () => {
+    render(<Connection />);
+    expect(screen.getByText(message)).toBeInTheDocument();
+  });
+
+  it('closes snackbar when close icon button is clicked', async () => {
+    render(<Connection />);
+    fireEvent.click(screen.getByLabelText('Close'));
+    await waitFor(() => {
+      expect(screen.queryByText(message)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/Connection/Connection.test.tsx
+++ b/src/components/Connection/Connection.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 
 import { onConnected } from '../../firebase/database';
 import Connection from './Connection';
@@ -11,6 +17,8 @@ const mockedOnConnected = jest.mocked(onConnected);
 
 const message = 'Unable to connect to server. Realtime updates are paused.';
 
+jest.useFakeTimers();
+
 describe('connected', () => {
   beforeEach(() => {
     const isConnected = true;
@@ -21,6 +29,7 @@ describe('connected', () => {
 
   it('does not render error', () => {
     render(<Connection />);
+    jest.runAllTimers();
     expect(screen.queryByText(message)).not.toBeInTheDocument();
   });
 });
@@ -35,11 +44,17 @@ describe('disconnected', () => {
 
   it('renders error when disconnected', () => {
     render(<Connection />);
+    act(() => {
+      jest.runAllTimers();
+    });
     expect(screen.getByText(message)).toBeInTheDocument();
   });
 
   it('closes snackbar when close icon button is clicked', async () => {
     render(<Connection />);
+    act(() => {
+      jest.runAllTimers();
+    });
     fireEvent.click(screen.getByLabelText('Close'));
     await waitFor(() => {
       expect(screen.queryByText(message)).not.toBeInTheDocument();

--- a/src/components/Connection/Connection.tsx
+++ b/src/components/Connection/Connection.tsx
@@ -9,7 +9,10 @@ export default function Connection() {
   const [connected, setConnected] = useState(true);
 
   useEffect(() => {
-    onConnected(setConnected);
+    // ensure app is loaded before checking Firebase connection
+    setTimeout(() => {
+      onConnected(setConnected);
+    }, 1000);
   }, []);
 
   function handleClose(event?: React.SyntheticEvent | Event, reason?: string) {

--- a/src/components/Connection/Connection.tsx
+++ b/src/components/Connection/Connection.tsx
@@ -1,0 +1,34 @@
+import Alert from '@mui/material/Alert';
+import Snackbar from '@mui/material/Snackbar';
+import { useEffect, useState } from 'react';
+
+import { onConnected } from '../../firebase/database';
+
+export default function Connection() {
+  const [open, setOpen] = useState(true);
+  const [connected, setConnected] = useState(true);
+
+  useEffect(() => {
+    onConnected(setConnected);
+  }, []);
+
+  function handleClose(event?: React.SyntheticEvent | Event, reason?: string) {
+    /* istanbul ignore if */
+    if (reason === 'clickaway') {
+      return;
+    }
+    setOpen(false);
+  }
+
+  return (
+    <Snackbar
+      anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+      onClose={handleClose}
+      open={open && !connected}
+    >
+      <Alert onClose={handleClose} severity="error">
+        Unable to connect to server. Realtime updates are paused.
+      </Alert>
+    </Snackbar>
+  );
+}

--- a/src/components/Connection/index.ts
+++ b/src/components/Connection/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Connection';

--- a/src/firebase/database.ts
+++ b/src/firebase/database.ts
@@ -4,6 +4,7 @@ import {
   child,
   get,
   getDatabase,
+  onValue,
   push,
   ref,
   remove,
@@ -51,6 +52,21 @@ export function generateId(): Id {
 }
 
 export const boardsRef = ref(database, BOARDS);
+
+/**
+ * Detects Firebase Realtime Database client's connection state change.
+ *
+ * @see {@link https://firebase.google.com/docs/database/web/offline-capabilities#section-connection-state}
+ *
+ * @param callback - The callback.
+ */
+export const onConnected = (callback: (isConnected: boolean) => void) => {
+  const connectedRef = ref(database, '.info/connected');
+  onValue(connectedRef, (snapshot) => {
+    const isConnected: boolean = snapshot.val();
+    callback(isConnected);
+  });
+};
 
 /**
  * Gets board ref.

--- a/src/pages/Board/index.tsx
+++ b/src/pages/Board/index.tsx
@@ -2,11 +2,13 @@ import CircularProgress from '@mui/material/CircularProgress';
 import { lazy, Suspense } from 'react';
 
 const Board = lazy(() => import('./Board'));
+const Connection = lazy(() => import('../../components/Connection'));
 
 export default function BoardLoader() {
   return (
     <Suspense fallback={<CircularProgress />}>
       <Board />
+      <Connection />
     </Suspense>
   );
 }

--- a/src/pages/Boards/index.tsx
+++ b/src/pages/Boards/index.tsx
@@ -2,11 +2,13 @@ import CircularProgress from '@mui/material/CircularProgress';
 import { lazy, Suspense } from 'react';
 
 const Boards = lazy(() => import('./Boards'));
+const Connection = lazy(() => import('../../components/Connection'));
 
 export default function BoardsLoader() {
   return (
     <Suspense fallback={<CircularProgress />}>
       <Boards />
+      <Connection />
     </Suspense>
   );
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: display error message when Firebase Realtime Database is disconnected

## What is the current behavior?

No error when Firebase Realtime Database client is disconnected (offline, network, etc.)

## What is the new behavior?

Error alert when Firebase Database client is disconnected

![Screen Shot 2023-03-08 at 9 09 39 PM](https://user-images.githubusercontent.com/10594555/223897594-965d1839-1d29-494f-9fe2-e46c87bdbf22.png)

https://firebase.google.com/docs/database/web/offline-capabilities#section-connection-state

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests