### PR TITLE
feat(pages): render custom error page

### DIFF
--- a/src/pages/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/src/pages/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,0 +1,46 @@
+import { screen } from '@testing-library/react';
+import { useRouteError } from 'react-router-dom';
+
+import { renderWithContext } from '../../utils/test';
+import ErrorBoundary from './ErrorBoundary';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useRouteError: jest.fn(),
+}));
+
+const mockedUseRouteError = jest.mocked(useRouteError);
+
+jest.spyOn(console, 'error');
+
+afterAll(() => {
+  jest.resetAllMocks();
+});
+
+it('renders heading', () => {
+  renderWithContext(<ErrorBoundary />);
+  expect(
+    screen.getByRole('heading', {
+      level: 1,
+      name: 'Error',
+    })
+  ).toBeInTheDocument();
+});
+
+it('renders error message', () => {
+  const error = new Error('test');
+  mockedUseRouteError.mockReturnValueOnce(error);
+  renderWithContext(<ErrorBoundary />);
+  expect(screen.getByText(error.toString())).toBeInTheDocument();
+  // eslint-disable-next-line no-console
+  expect(console.error).toBeCalledWith(error);
+});
+
+it('renders home link', () => {
+  renderWithContext(<ErrorBoundary />);
+  expect(
+    screen.getByRole('link', {
+      name: 'home',
+    })
+  ).toHaveAttribute('href', '/');
+});

--- a/src/pages/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/pages/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,39 @@
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
+import Link from '@mui/material/Link';
+import Typography from '@mui/material/Typography';
+import { Link as RouterLink, useRouteError } from 'react-router-dom';
+
+import { useSetDocumentTitle } from '../../hooks';
+
+export default function ErrorBoundary() {
+  useSetDocumentTitle('Error');
+  const error = useRouteError();
+  // eslint-disable-next-line no-console
+  console.error(error);
+
+  return (
+    <>
+      <Typography component="h1" paragraph variant="h4">
+        Error
+      </Typography>
+
+      <Alert severity="error">
+        <AlertTitle>Unexpected Application Error</AlertTitle>
+        <pre>
+          <code>{String(error)}</code>
+        </pre>
+      </Alert>
+
+      <br />
+
+      <Typography paragraph>
+        Refresh the page or go to{' '}
+        <Link component={RouterLink} to="/">
+          home
+        </Link>
+        .
+      </Typography>
+    </>
+  );
+}

--- a/src/pages/ErrorBoundary/index.tsx
+++ b/src/pages/ErrorBoundary/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './ErrorBoundary';

--- a/src/routes/index.test.tsx
+++ b/src/routes/index.test.tsx
@@ -7,54 +7,58 @@ it('matches snapshot', () => {
       path="/"
     >
       <Route
-        element={<HomeLoader />}
-        index={true}
-      />
-      <Route
-        element={<LoginLoader />}
-        path="login"
-      />
-      <Route
-        element={<LogoutLoader />}
-        path="logout"
-      />
-      <Route
-        element={<SupportLoader />}
-        path="support"
-      />
-      <Route
-        path="boards"
+        errorElement={<ErrorBoundary />}
       >
         <Route
-          element={
-            <ProtectedLoader
-              check="email"
-            />
-          }
+          element={<HomeLoader />}
+          index={true}
+        />
+        <Route
+          element={<LoginLoader />}
+          path="login"
+        />
+        <Route
+          element={<LogoutLoader />}
+          path="logout"
+        />
+        <Route
+          element={<SupportLoader />}
+          path="support"
+        />
+        <Route
+          path="boards"
         >
           <Route
-            element={<BoardsLoader />}
-            index={true}
-          />
+            element={
+              <ProtectedLoader
+                check="email"
+              />
+            }
+          >
+            <Route
+              element={<BoardsLoader />}
+              index={true}
+            />
+          </Route>
+          <Route
+            element={
+              <ProtectedLoader
+                check="id"
+                signInAnonymously={true}
+              />
+            }
+          >
+            <Route
+              element={<BoardLoader />}
+              path=":boardId"
+            />
+          </Route>
         </Route>
         <Route
-          element={
-            <ProtectedLoader
-              check="id"
-              signInAnonymously={true}
-            />
-          }
-        >
-          <Route
-            element={<BoardLoader />}
-            path=":boardId"
-          />
-        </Route>
+          element={<NotFoundLoader />}
+          path="*"
+        />
       </Route>
-      <Route
-        element={<NotFoundLoader />}
-        path="*"
-      />
     </Route>
   `);
 });

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -5,6 +5,7 @@ import Layout from '../components/Layout';
 import Protected from '../components/Protected';
 import Board from '../pages/Board';
 import Boards from '../pages/Boards';
+import ErrorBoundary from '../pages/ErrorBoundary';
 import Home from '../pages/Home';
 import Login from '../pages/Login';
 import Logout from '../pages/Logout';
@@ -13,23 +14,25 @@ import Support from '../pages/Support';
 
 const routes: ReactElement = (
   <Route path="/" element={<Layout />}>
-    <Route index element={<Home />} />
+    <Route errorElement={<ErrorBoundary />}>
+      <Route index element={<Home />} />
 
-    <Route path="login" element={<Login />} />
-    <Route path="logout" element={<Logout />} />
-    <Route path="support" element={<Support />} />
+      <Route path="login" element={<Login />} />
+      <Route path="logout" element={<Logout />} />
+      <Route path="support" element={<Support />} />
 
-    <Route path="boards">
-      <Route element={<Protected check="email" />}>
-        <Route index element={<Boards />} />
+      <Route path="boards">
+        <Route element={<Protected check="email" />}>
+          <Route index element={<Boards />} />
+        </Route>
+
+        <Route element={<Protected check="id" signInAnonymously />}>
+          <Route path=":boardId" element={<Board />} />
+        </Route>
       </Route>
 
-      <Route element={<Protected check="id" signInAnonymously />}>
-        <Route path=":boardId" element={<Board />} />
-      </Route>
+      <Route path="*" element={<NotFound />} />
     </Route>
-
-    <Route path="*" element={<NotFound />} />
   </Route>
 );
 


### PR DESCRIPTION
## What is the motivation for this pull request?

Replace react-router-dom's default error page with customized error page

## What is the current behavior?

No customized error page

## What is the new behavior?

Customized error page `<ErrorBoundary>` that's consistent the Lilboards UI

![Screen Shot 2023-03-09 at 7 46 56 PM](https://user-images.githubusercontent.com/10594555/224195233-f287a8a0-2462-41b2-8d78-a61437927ee1.png)

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests