### PR TITLE
feat(BoardCard): show confirmation dialog before deleting board

### DIFF
--- a/cypress/e2e/boards/boards.feature
+++ b/cypress/e2e/boards/boards.feature
@@ -13,8 +13,15 @@ Feature: Boards
       And I see link "Open"
       And I see button "Delete"
     When I click on button "Add board"
-      And I get focused element
-      And I type "My Board 2"
-    When I click on button "Delete"
       And I click on button "Delete"
-    Then I do not see text "Board Name"
+    Then I see text "Delete board?"
+      And I see text "This action cannot be undone."
+    When I find buttons by text "Delete"
+      And I get last element
+      And I click
+      And I find links by text "Open"
+    Then I count 1 element
+    When I click on button "Delete"
+    Then I see text 'Delete board "My Board 1"?'
+    When I click on button "Cancel"
+    Then I see text "My Board 1"

--- a/src/pages/Boards/BoardCard.test.tsx
+++ b/src/pages/Boards/BoardCard.test.tsx
@@ -58,15 +58,38 @@ describe('edit board', () => {
 
 describe('delete board', () => {
   let board: ReturnType<typeof updateStore.withBoard>;
+  const dialogContent = 'This action cannot be undone.';
 
   beforeEach(() => {
     board = updateStore.withBoard();
     updateStore.withUser();
   });
 
+  it('renders dialog', () => {
+    renderWithContext(<BoardCard boardId={board.id} />);
+    fireEvent.click(screen.getByLabelText(`Delete board "${board.name}"`));
+    expect(
+      screen.getByText(`Delete board "${board.name}"?`)
+    ).toBeInTheDocument();
+    expect(screen.getByText(dialogContent)).toBeInTheDocument();
+  });
+
+  it('does not delete board', () => {
+    board = updateStore.withBoard({ name: '' });
+    updateStore.withUser();
+    renderWithContext(<BoardCard boardId={board.id} />);
+    fireEvent.click(screen.getByLabelText('Delete board'));
+    expect(screen.getByText('Delete board?')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(screen.queryByText(dialogContent)).not.toBeVisible();
+    expect(screen.getByLabelText('Board Name')).toBeInTheDocument();
+  });
+
   it('deletes board', () => {
     renderWithContext(<BoardCard boardId={board.id} />);
     fireEvent.click(screen.getByLabelText(/Delete board/));
-    expect(screen.queryByLabelText('Board Name')).not.toBeInTheDocument();
+    fireEvent.click(screen.getAllByText('Delete')[1]);
+    expect(screen.queryByText(dialogContent)).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue(board.name)).not.toBeInTheDocument();
   });
 });

--- a/src/pages/Boards/BoardCard.tsx
+++ b/src/pages/Boards/BoardCard.tsx
@@ -2,9 +2,14 @@ import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardActions from '@mui/material/CardActions';
 import CardContent from '@mui/material/CardContent';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
 import Grid from '@mui/material/Grid';
 import TextField from '@mui/material/TextField';
-import type { ChangeEvent } from 'react';
+import { type ChangeEvent, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import actions from '../../actions';
@@ -23,6 +28,7 @@ export default function BoardCard(props: Props) {
     (state) => state.user.editing.boardId === props.boardId
   );
   const userId = useSelector((state) => state.user.id);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   if (!board) {
     return null;
@@ -95,9 +101,46 @@ export default function BoardCard(props: Props) {
             Open
           </Button>
 
-          <Button aria-label="Delete board" color="error" onClick={deleteBoard}>
+          <Button
+            aria-label={
+              board.name ? `Delete board "${board.name}"` : 'Delete board'
+            }
+            color="error"
+            onClick={() => setIsDialogOpen(true)}
+          >
             Delete
           </Button>
+
+          <Dialog
+            open={isDialogOpen}
+            onClose={/* istanbul ignore next */ () => setIsDialogOpen(false)}
+            aria-labelledby={`dialog-title-${props.boardId}`}
+            aria-describedby={`dialog-content-${props.boardId}`}
+          >
+            <DialogTitle id={`dialog-title-${props.boardId}`}>
+              {board.name ? `Delete board "${board.name}"?` : 'Delete board?'}
+            </DialogTitle>
+
+            <DialogContent>
+              <DialogContentText id={`dialog-content-${props.boardId}`}>
+                This action cannot be undone.
+              </DialogContentText>
+            </DialogContent>
+
+            <DialogActions>
+              <Button onClick={() => setIsDialogOpen(false)}>Cancel</Button>
+              <Button
+                autoFocus
+                color="error"
+                onClick={() => {
+                  deleteBoard();
+                  setIsDialogOpen(false);
+                }}
+              >
+                Delete
+              </Button>
+            </DialogActions>
+          </Dialog>
         </CardActions>
       </Card>
     </Grid>


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(BoardCard): show confirmation dialog before deleting board

<img width="300" alt="Screen Shot 2023-03-19 at 3 12 43 PM" src="https://user-images.githubusercontent.com/10594555/226203355-f113bdfc-327b-4550-a51c-75fe4a8e7588.png">

## What is the current behavior?

No confirmation popup before deleting board

## What is the new behavior?

Confirmation popup before deleting board

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests