### PR TITLE
feat: confirm before deleting column

### DIFF
--- a/cypress/e2e/board/board.feature
+++ b/cypress/e2e/board/board.feature
@@ -17,7 +17,8 @@ Feature: Board
       And I type "Item 1"
       And I blur
     Then I see text "Item 1"
-    When I click on label 'Delete column "Column 1"'
+    When I click on label "Delete column “Column 1”"
+      And I click on button "Delete"
     Then I do not see text "Column 1"
       And I do not see text "Item 1"
     When I click on button "Add column"

--- a/cypress/e2e/boards/boards.feature
+++ b/cypress/e2e/boards/boards.feature
@@ -22,6 +22,6 @@ Feature: Boards
       And I find links by text "Open"
     Then I count 1 element
     When I click on button "Delete"
-    Then I see text 'Delete board "My Board 1"?'
+    Then I see text "Delete board “My Board 1”?"
     When I click on button "Cancel"
     Then I see text "My Board 1"

--- a/src/components/CloseButton/CloseButton.tsx
+++ b/src/components/CloseButton/CloseButton.tsx
@@ -4,7 +4,7 @@ import IconButton from '@mui/material/IconButton';
 
 export default function CloseButton(props: IconButtonProps) {
   return (
-    <IconButton {...props} size="large">
+    <IconButton size="large" {...props}>
       <CloseIcon />
     </IconButton>
   );

--- a/src/components/Column/Column.test.tsx
+++ b/src/components/Column/Column.test.tsx
@@ -31,7 +31,7 @@ it('edits column', () => {
     <Column {...props} boardId={board.id} columnId={column.id} />
   );
   const value = 'Edited Column Name';
-  fireEvent.change(screen.getByLabelText(`Edit column "${column.name}"`), {
+  fireEvent.change(screen.getByLabelText(`Edit column “${column.name}”`), {
     target: { value },
   });
   expect(screen.getByDisplayValue(value)).toBeInTheDocument();
@@ -45,17 +45,38 @@ it('resets user editing column id on blur', () => {
   renderWithContext(
     <Column {...props} boardId={board.id} columnId={column.id} />
   );
-  fireEvent.blur(screen.getByLabelText(`Edit column "${column.name}"`));
+  fireEvent.blur(screen.getByLabelText(`Edit column “${column.name}”`));
   expect(store.getState().user.editing.columnId).toBe('');
 });
 
-it('deletes column', () => {
-  const board = updateStore.withBoard();
-  const column = updateStore.withColumn();
-  updateStore.withUser();
-  renderWithContext(
-    <Column {...props} boardId={board.id} columnId={column.id} />
-  );
-  fireEvent.click(screen.getByLabelText(/Delete column/));
-  expect(screen.queryByText(column.name)).not.toBeInTheDocument();
+describe('delete', () => {
+  let board: ReturnType<typeof updateStore.withBoard>;
+  let column: ReturnType<typeof updateStore.withColumn>;
+  const dialogContent = 'This action cannot be undone.';
+
+  beforeEach(() => {
+    board = updateStore.withBoard();
+    column = updateStore.withColumn();
+    updateStore.withUser();
+  });
+
+  it('cancels delete', () => {
+    renderWithContext(
+      <Column {...props} boardId={board.id} columnId={column.id} />
+    );
+    fireEvent.click(screen.getByLabelText(/Delete column/));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByText(dialogContent)).not.toBeVisible();
+    expect(screen.getByDisplayValue(column.name)).toBeInTheDocument();
+  });
+
+  it('deletes column', () => {
+    renderWithContext(
+      <Column {...props} boardId={board.id} columnId={column.id} />
+    );
+    fireEvent.click(screen.getByLabelText(/Delete column/));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(screen.queryByText(dialogContent)).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue(column.name)).not.toBeInTheDocument();
+  });
 });

--- a/src/components/Column/ColumnName.test.tsx
+++ b/src/components/Column/ColumnName.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 
 import {
   BOARD_TEST_ID as boardId,
@@ -44,7 +44,7 @@ describe('edit', () => {
     updateStore.withUser();
     renderWithContext(<ColumnName {...props} boardId={board.id} />);
     expect(
-      screen.getByLabelText(`Edit column "${props.name}"`)
+      screen.getByLabelText(`Edit column “${props.name}”`)
     ).toBeInTheDocument();
   });
 
@@ -53,28 +53,38 @@ describe('edit', () => {
     updateStore.withUser();
     renderWithContext(<ColumnName {...props} boardId={board.id} name="" />);
     expect(
-      screen.getByLabelText(`Edit column "${props.placeholder}"`)
+      screen.getByLabelText(`Edit column “${props.placeholder}”`)
     ).toBeInTheDocument();
   });
 });
 
 // user can delete (board owner)
 describe('delete', () => {
-  it('renders button with name', () => {
-    const board = updateStore.withBoard();
+  let board: ReturnType<typeof updateStore.withBoard>;
+  const dialogContent = 'This action cannot be undone.';
+
+  beforeEach(() => {
+    board = updateStore.withBoard();
     updateStore.withUser();
-    renderWithContext(<ColumnName {...props} boardId={board.id} />);
-    expect(
-      screen.getByLabelText(`Delete column "${props.name}"`)
-    ).toBeInTheDocument();
   });
 
-  it('renders button with placeholder', () => {
-    const board = updateStore.withBoard();
-    updateStore.withUser();
-    renderWithContext(<ColumnName {...props} boardId={board.id} name="" />);
+  it('renders dialog with name', () => {
+    const columnName = props.name;
+    renderWithContext(<ColumnName {...props} boardId={board.id} />);
+    fireEvent.click(screen.getByLabelText(`Delete column “${columnName}”`));
     expect(
-      screen.getByLabelText(`Delete column "${props.placeholder}"`)
+      screen.getByText(`Delete column “${columnName}”?`)
     ).toBeInTheDocument();
+    expect(screen.getByText(dialogContent)).toBeInTheDocument();
+  });
+
+  it('renders dialog with default name', () => {
+    const columnName = props.placeholder;
+    renderWithContext(<ColumnName {...props} boardId={board.id} name="" />);
+    fireEvent.click(screen.getByLabelText(`Delete column “${columnName}”`));
+    expect(
+      screen.getByText(`Delete column “${columnName}”?`)
+    ).toBeInTheDocument();
+    expect(screen.getByText(dialogContent)).toBeInTheDocument();
   });
 });

--- a/src/components/Column/ColumnName.tsx
+++ b/src/components/Column/ColumnName.tsx
@@ -101,8 +101,9 @@ export default function ColumnName(props: Props) {
         size="small"
         sx={{
           position: 'absolute',
-          right: 0,
-          top: 0,
+          right: 4,
+          top: '50%',
+          transform: 'translateY(-50%)',
         }}
       />
 

--- a/src/components/Column/ColumnName.tsx
+++ b/src/components/Column/ColumnName.tsx
@@ -1,8 +1,9 @@
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import type { ChangeEvent } from 'react';
+import { type ChangeEvent, useState } from 'react';
 
 import actions from '../../actions';
+import DeleteDialog from '../../components/DeleteDialog';
 import { logEvent } from '../../firebase';
 import { useDispatch, useSelector } from '../../hooks';
 import type { Id } from '../../types';
@@ -27,6 +28,7 @@ export default function ColumnName(props: Props) {
     (state) => (state.columns[props.columnId] || {}).itemIds || []
   );
   const userId = useSelector((state) => state.user.id);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
   const columnName = props.name || props.placeholder;
 
   if (readOnly) {
@@ -84,7 +86,9 @@ export default function ColumnName(props: Props) {
       <TextField
         autoFocus={isEditing}
         fullWidth
-        inputProps={{ 'aria-label': `Edit column "${columnName}"` }}
+        inputProps={{
+          'aria-label': `Edit column “${columnName}”`,
+        }}
         placeholder={props.placeholder}
         onBlur={handleBlur}
         onChange={handleChange}
@@ -92,14 +96,26 @@ export default function ColumnName(props: Props) {
       />
 
       <CloseButton
-        aria-label={`Delete column "${columnName}"`}
-        onClick={deleteColumn}
+        aria-label={`Delete column “${columnName}”`}
+        onClick={() => setIsDialogOpen(true)}
         size="small"
         sx={{
           position: 'absolute',
           right: 0,
           top: 0,
         }}
+      />
+
+      <DeleteDialog
+        content="This action cannot be undone."
+        id={props.columnId}
+        onClose={() => setIsDialogOpen(false)}
+        onDelete={() => {
+          deleteColumn();
+          setIsDialogOpen(false);
+        }}
+        open={isDialogOpen}
+        title={`Delete column “${columnName}”?`}
       />
     </>
   );

--- a/src/pages/Boards/BoardCard.test.tsx
+++ b/src/pages/Boards/BoardCard.test.tsx
@@ -65,24 +65,30 @@ describe('delete board', () => {
     updateStore.withUser();
   });
 
-  it('renders dialog', () => {
+  it('renders dialog with name', () => {
     renderWithContext(<BoardCard boardId={board.id} />);
-    fireEvent.click(screen.getByLabelText(`Delete board "${board.name}"`));
+    fireEvent.click(screen.getByLabelText(`Delete board “${board.name}”`));
     expect(
-      screen.getByText(`Delete board "${board.name}"?`)
+      screen.getByText(`Delete board “${board.name}”?`)
     ).toBeInTheDocument();
     expect(screen.getByText(dialogContent)).toBeInTheDocument();
   });
 
-  it('does not delete board', () => {
+  it('renders dialog with no name', () => {
     board = updateStore.withBoard({ name: '' });
     updateStore.withUser();
     renderWithContext(<BoardCard boardId={board.id} />);
     fireEvent.click(screen.getByLabelText('Delete board'));
     expect(screen.getByText('Delete board?')).toBeInTheDocument();
-    fireEvent.click(screen.getByText('Cancel'));
+    expect(screen.getByText(dialogContent)).toBeInTheDocument();
+  });
+
+  it('cancels delete', () => {
+    renderWithContext(<BoardCard boardId={board.id} />);
+    fireEvent.click(screen.getByLabelText(/Delete board/));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(screen.queryByText(dialogContent)).not.toBeVisible();
-    expect(screen.getByLabelText('Board Name')).toBeInTheDocument();
+    expect(screen.getByDisplayValue(board.name)).toBeInTheDocument();
   });
 
   it('deletes board', () => {

--- a/src/pages/Boards/BoardCard.tsx
+++ b/src/pages/Boards/BoardCard.tsx
@@ -99,7 +99,7 @@ export default function BoardCard(props: Props) {
 
           <Button
             aria-label={
-              board.name ? `Delete board "${board.name}"` : 'Delete board'
+              board.name ? `Delete board “${board.name}”` : 'Delete board'
             }
             color="error"
             onClick={() => setIsDialogOpen(true)}
@@ -117,7 +117,7 @@ export default function BoardCard(props: Props) {
             }}
             open={isDialogOpen}
             title={
-              board.name ? `Delete board "${board.name}"?` : 'Delete board?'
+              board.name ? `Delete board “${board.name}”?` : 'Delete board?'
             }
           />
         </CardActions>


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: confirm before deleting column

## What is the current behavior?

Instant deletion of column when close icon is clicked

## What is the new behavior?

Dialog pops up to confirm before deleting column

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests