### PR TITLE
feat(components): replace double quotes inside Item aria-label

### DIFF
--- a/cypress/e2e/board/board.feature
+++ b/cypress/e2e/board/board.feature
@@ -54,7 +54,7 @@ Feature: Board
       And I type "Item to Delete"
       And I blur
     Then I see text "Item to Delete"
-    When I click on label 'Delete item "Item to Delete"'
+    When I click on label "Delete item “Item to Delete”"
     Then I do not see text "Item to Delete"
     When I reload the page
     Then I see text "Create board, columns, and items"
@@ -101,5 +101,5 @@ Feature: Board
       And I type "Item Two"
       And I click on text "Hide Likes"
     Then I see text "Item Two"
-    When I click on label 'Delete item "Item One"'
+    When I click on label "Delete item “Item One”"
     Then I do not see text "Item One"

--- a/src/components/Item/Item.test.tsx
+++ b/src/components/Item/Item.test.tsx
@@ -48,13 +48,13 @@ describe('delete item', () => {
   it('renders close button', () => {
     renderWithContext(<Item {...props} itemId={item.id} />);
     expect(
-      screen.getByLabelText(`Delete item "${item.text}"`)
+      screen.getByLabelText(`Delete item “${item.text}”`)
     ).toBeInTheDocument();
   });
 
   it('deletes item', () => {
     renderWithContext(<Item {...props} itemId={item.id} />);
-    fireEvent.click(screen.getByLabelText(`Delete item "${item.text}"`));
+    fireEvent.click(screen.getByLabelText(`Delete item “${item.text}”`));
     expect(screen.queryByLabelText(/Delete item/)).not.toBeInTheDocument();
   });
 });
@@ -67,20 +67,20 @@ describe('edit item', () => {
   it('changes item', () => {
     renderWithContext(<Item {...props} itemId={item.id} />);
     const event = { target: { value: 'Item text' } };
-    const input = screen.getByLabelText(`Edit item "${item.text}"`);
+    const input = screen.getByLabelText(`Edit item “${item.text}”`);
     fireEvent.change(input, event);
     expect(screen.getByDisplayValue(event.target.value)).toBe(input);
   });
 
   it('focuses item', () => {
     renderWithContext(<Item {...props} itemId={item.id} />);
-    fireEvent.focus(screen.getByLabelText(`Edit item "${item.text}"`));
+    fireEvent.focus(screen.getByLabelText(`Edit item “${item.text}”`));
     expect(store.getState().user.editing.itemId).toBe(itemId);
   });
 
   it('blurs item', () => {
     renderWithContext(<Item {...props} itemId={item.id} />);
-    fireEvent.blur(screen.getByLabelText(`Edit item "${item.text}"`));
+    fireEvent.blur(screen.getByLabelText(`Edit item “${item.text}”`));
     expect(store.getState().user.editing.itemId).toBe('');
   });
 });

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -87,7 +87,7 @@ export default function Item(props: Props) {
     <Box height="100%" position="relative">
       <Card raised={isEditing} style={props.cardStyle}>
         <CloseButton
-          aria-label={`Delete item "${item.text}"`}
+          aria-label={`Delete item “${item.text}”`}
           onClick={deleteItem}
           size="small"
           sx={{
@@ -101,7 +101,9 @@ export default function Item(props: Props) {
           autoFocus={isEditing}
           components={{ Root: CardContent }}
           fullWidth
-          inputProps={{ 'aria-label': `Edit item "${item.text}"` }}
+          inputProps={{
+            'aria-label': `Edit item “${item.text}”`,
+          }}
           multiline
           onBlur={handleBlur}
           onChange={handleChange}


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(components): replace double quotes inside Item aria-label

## What is the current behavior?

Item aria-label uses `""`

## What is the new behavior?

Item aria-label uses `“”`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests