### PR TITLE
feat(Item): confirm with dialog before delete

### DIFF
--- a/cypress/e2e/board/board.feature
+++ b/cypress/e2e/board/board.feature
@@ -55,6 +55,7 @@ Feature: Board
       And I blur
     Then I see text "Item to Delete"
     When I click on label "Delete item “Item to Delete”"
+      And I click on button "Delete"
     Then I do not see text "Item to Delete"
     When I reload the page
     Then I see text "Create board, columns, and items"
@@ -102,4 +103,5 @@ Feature: Board
       And I click on text "Hide Likes"
     Then I see text "Item Two"
     When I click on label "Delete item “Item One”"
+      And I click on button "Delete"
     Then I do not see text "Item One"

--- a/src/components/Item/Delete.test.tsx
+++ b/src/components/Item/Delete.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, screen } from '@testing-library/react';
+
+import { renderWithProviders, store, updateStore } from '../../utils/test';
+import Delete from './Delete';
+
+const dialogTitle = 'Are you sure you want to delete?';
+const dialogContent = 'This action cannot be undone.';
+
+let props = {
+  boardId: '',
+  columnId: '',
+  itemId: '',
+  itemText: '',
+};
+
+beforeEach(() => {
+  const board = updateStore.withBoard();
+  const column = updateStore.withColumn();
+  const item = updateStore.withItem();
+  props.boardId = board.id;
+  props.columnId = column.id;
+  props.itemId = item.id;
+  props.itemText = item.text;
+});
+
+it('renders delete button', () => {
+  renderWithProviders(<Delete {...props} />);
+  expect(
+    screen.getByLabelText(`Delete item “${props.itemText}”`)
+  ).toBeInTheDocument();
+});
+
+it('renders delete dialog', () => {
+  renderWithProviders(<Delete {...props} />);
+  fireEvent.click(screen.getByLabelText(`Delete item “${props.itemText}”`));
+  expect(screen.getByText(dialogTitle)).toBeVisible();
+  expect(screen.getByText(dialogContent)).toBeVisible();
+});
+
+it('cancels delete', () => {
+  renderWithProviders(<Delete {...props} />);
+  fireEvent.click(screen.getByLabelText(`Delete item “${props.itemText}”`));
+  fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+  expect(screen.getByText(dialogTitle)).not.toBeVisible();
+  expect(
+    screen.getByLabelText(`Delete item “${props.itemText}”`)
+  ).toBeInTheDocument();
+});
+
+it('confirms delete', () => {
+  renderWithProviders(<Delete {...props} />);
+  fireEvent.click(screen.getByLabelText(`Delete item “${props.itemText}”`));
+  fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+  expect(screen.getByText(dialogTitle)).not.toBeVisible();
+  const state = store.getState();
+  expect(state).toMatchObject({
+    items: {},
+    likes: { items: {} },
+  });
+  expect(state.columns[props.columnId].itemIds).toEqual([]);
+});

--- a/src/components/Item/Delete.tsx
+++ b/src/components/Item/Delete.tsx
@@ -1,0 +1,74 @@
+import { useCallback, useState } from 'react';
+
+import actions from '../../actions';
+import DeleteDialog from '../../components/DeleteDialog';
+import { logEvent } from '../../firebase';
+import { useDispatch } from '../../hooks';
+import type { Id } from '../../types';
+import CloseButton from '../CloseButton';
+
+interface Props {
+  boardId: Id;
+  columnId: Id;
+  itemId: Id;
+  itemText: string;
+}
+
+export default function Delete(props: Props) {
+  const dispatch = useDispatch();
+  const [open, setOpen] = useState(false);
+  const openDialog = useCallback(() => setOpen(true), [setOpen]);
+  const closeDialog = useCallback(() => setOpen(false), [setOpen]);
+
+  const deleteItem = useCallback(() => {
+    dispatch(
+      actions.removeItem({
+        boardId: props.boardId,
+        itemId: props.itemId,
+      })
+    );
+    dispatch(
+      actions.removeColumnItemId({
+        boardId: props.boardId,
+        columnId: props.columnId,
+        itemId: props.itemId,
+      })
+    );
+    dispatch(
+      actions.removeLikesItem({
+        boardId: props.boardId,
+        itemId: props.itemId,
+      })
+    );
+    logEvent('delete_item');
+    closeDialog();
+  }, [closeDialog, dispatch, props]);
+
+  return (
+    <>
+      <CloseButton
+        aria-label={`Delete item “${props.itemText}”`}
+        onClick={openDialog}
+        size="small"
+        sx={styles.closeButton}
+      />
+
+      <DeleteDialog
+        content="This action cannot be undone."
+        id={props.itemId}
+        onClose={closeDialog}
+        onDelete={deleteItem}
+        open={open}
+        title="Are you sure you want to delete?"
+      />
+    </>
+  );
+}
+
+const styles = {
+  closeButton: {
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
+};

--- a/src/components/Item/Item.test.tsx
+++ b/src/components/Item/Item.test.tsx
@@ -45,7 +45,7 @@ describe('delete item', () => {
     item = updateStore.withItem();
   });
 
-  it('renders close button', () => {
+  it('renders delete button', () => {
     renderWithProviders(<Item {...props} itemId={item.id} />);
     expect(
       screen.getByLabelText(`Delete item “${item.text}”`)
@@ -55,6 +55,7 @@ describe('delete item', () => {
   it('deletes item', () => {
     renderWithProviders(<Item {...props} itemId={item.id} />);
     fireEvent.click(screen.getByLabelText(`Delete item “${item.text}”`));
+    fireEvent.click(screen.getByText('Delete'));
     expect(screen.queryByLabelText(/Delete item/)).not.toBeInTheDocument();
   });
 });

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -8,7 +8,7 @@ import actions from '../../actions';
 import { logEvent } from '../../firebase';
 import { useDispatch, useSelector } from '../../hooks';
 import type { Id } from '../../types';
-import CloseButton from '../CloseButton';
+import Delete from './Delete';
 import Likes from './Likes';
 
 interface Props {
@@ -28,29 +28,6 @@ export default function Item(props: Props) {
 
   if (!item) {
     return null;
-  }
-
-  function deleteItem() {
-    dispatch(
-      actions.removeItem({
-        boardId: props.boardId,
-        itemId: props.itemId,
-      })
-    );
-    dispatch(
-      actions.removeColumnItemId({
-        boardId: props.boardId,
-        columnId: props.columnId,
-        itemId: props.itemId,
-      })
-    );
-    dispatch(
-      actions.removeLikesItem({
-        boardId: props.boardId,
-        itemId: props.itemId,
-      })
-    );
-    logEvent('delete_item');
   }
 
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
@@ -86,15 +63,11 @@ export default function Item(props: Props) {
   return (
     <Box height="100%" position="relative">
       <Card raised={isEditing} style={props.cardStyle}>
-        <CloseButton
-          aria-label={`Delete item “${item.text}”`}
-          onClick={deleteItem}
-          size="small"
-          sx={{
-            position: 'absolute',
-            right: 0,
-            top: 0,
-          }}
+        <Delete
+          boardId={props.boardId}
+          columnId={props.columnId}
+          itemId={props.itemId}
+          itemText={item.text}
         />
 
         <InputBase


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(Item): confirm with dialog before delete

## What is the current behavior?

Item deletes immediately when close button is clicked

## What is the new behavior?

Ask user to confirm item deletion when close button is clicked

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests