### PR TITLE
refactor(hooks): bump react-redux to 8.1.0 and update useSelector hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react": "^18.2.0",
     "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^18.2.0",
-    "react-redux": "^8.0.7",
+    "react-redux": "^8.1.0",
     "react-router-dom": "^6.12.0",
     "react-scripts": "5.0.1",
     "typescript": "5.1.3",

--- a/src/hooks/useSelector.test.ts
+++ b/src/hooks/useSelector.test.ts
@@ -1,13 +1,9 @@
 import { renderHook } from '@testing-library/react';
-import {
-  shallowEqual,
-  useSelector as useReactReduxSelector,
-} from 'react-redux';
+import { useSelector as useReactReduxSelector } from 'react-redux';
 
 import { useSelector } from './useSelector';
 
 jest.mock('react-redux', () => ({
-  shallowEqual: jest.fn(),
   useSelector: jest.fn(),
 }));
 
@@ -15,10 +11,10 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-it('wraps react-redux useSelector with shallowEqual', () => {
+it('returns react-redux useSelector', () => {
   const selector = jest.fn();
   const { result } = renderHook(() => useSelector(selector));
   expect(result.current).toBe(undefined);
   expect(useReactReduxSelector).toBeCalledTimes(1);
-  expect(useReactReduxSelector).toBeCalledWith(selector, shallowEqual);
+  expect(useReactReduxSelector).toBeCalledWith(selector);
 });

--- a/src/hooks/useSelector.ts
+++ b/src/hooks/useSelector.ts
@@ -1,12 +1,7 @@
 import type { TypedUseSelectorHook } from 'react-redux';
-import {
-  shallowEqual,
-  useSelector as useReactReduxSelector,
-} from 'react-redux';
+import { useSelector as useReactReduxSelector } from 'react-redux';
 
 import type { RootState } from '../types';
 
-export const useSelector: TypedUseSelectorHook<RootState> = (
-  selector,
-  equalityFn = shallowEqual
-) => useReactReduxSelector(selector, equalityFn);
+export const useSelector: TypedUseSelectorHook<RootState> =
+  useReactReduxSelector;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12839,10 +12839,10 @@ react-redux@^7.2.0:
     prop-types "^15.7.2"
     react-is "^17.0.2"
 
-react-redux@^8.0.7:
-  version "8.0.7"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-8.0.7.tgz#b74ef2f7ce2076e354540aa3511d3670c2b62571"
-  integrity sha512-1vRQuCQI5Y2uNmrMXg81RXKiBHY3jBzvCvNmZF437O/Z9/pZ+ba2uYHbemYXb3g8rjsacBGo+/wmfrQKzMhJsg==
+react-redux@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-8.1.0.tgz#4e147339f00bbaac7196bc42bc99e6fc412846e7"
+  integrity sha512-CtHZzAOxi7GQvTph4dVLWwZHAWUjV2kMEQtk50OrN8z3gKxpWg3Tz7JfDw32N3Rpd7fh02z73cF6yZkK467gbQ==
   dependencies:
     "@babel/runtime" "^7.12.1"
     "@types/hoist-non-react-statics" "^3.3.1"


### PR DESCRIPTION
Relates to adbf16b

```
Error: src/hooks/useSelector.ts(12,38): error TS2769: No overload matches this call.
  Overload 1 of 2, '(selector: (state: { boards: Boards; columns: Columns; items: Items; likes: Likes; user: User; }) => NoInfer<TSelected>, equalityFn?: EqualityFn<...> | undefined): NoInfer<...>', gave the following error.
    Argument of type 'EqualityFn<NoInfer<TSelected>> | UseSelectorOptions<TSelected>' is not assignable to parameter of type 'EqualityFn<NoInfer<TSelected>> | undefined'.
      Type 'UseSelectorOptions<TSelected>' is not assignable to type 'EqualityFn<NoInfer<TSelected>>'.
        Type 'UseSelectorOptions<TSelected>' provides no match for the signature '(a: NoInfer<TSelected>, b: NoInfer<TSelected>): boolean'.
  Overload 2 of 2, '(selector: (state: { boards: Boards; columns: Columns; items: Items; likes: Likes; user: User; }) => TSelected, options?: UseSelectorOptions<TSelected> | undefined): TSelected', gave the following error.
    Argument of type 'EqualityFn<NoInfer<TSelected>> | UseSelectorOptions<TSelected>' is not assignable to parameter of type 'UseSelectorOptions<TSelected> | undefined'.
      Type 'EqualityFn<NoInfer<TSelected>>' has no properties in common with type 'UseSelectorOptions<TSelected>'.
```

https://github.com/reduxjs/react-redux/releases/tag/v8.1.0