### PR TITLE
feat(Header): change the SupportIcon to the HelpIcon

### DIFF
--- a/src/components/Layout/Header.test.tsx
+++ b/src/components/Layout/Header.test.tsx
@@ -23,9 +23,9 @@ it('renders support link', () => {
 
 it('renders GitHub link', () => {
   renderWithProviders(<Header />);
-  expect(screen.getByLabelText('Open GitHub repository')).toHaveAttribute(
+  expect(screen.getByLabelText('GitHub')).toHaveAttribute(
     'href',
-    'https://b.remarkabl.org/lilboards'
+    'https://github.com/lilboards/lilboards'
   );
 });
 

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -1,5 +1,5 @@
 import GitHubIcon from '@mui/icons-material/GitHub';
-import SupportIcon from '@mui/icons-material/Support';
+import HelpIcon from '@mui/icons-material/Help';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -39,14 +39,14 @@ export default function Header() {
             to="/support"
             title="Support"
           >
-            <SupportIcon />
+            <HelpIcon />
           </IconButton>
 
           <Link
-            aria-label="Open GitHub repository"
+            aria-label="GitHub"
             color="inherit"
             component={IconButton}
-            href="https://b.remarkabl.org/lilboards"
+            href="https://github.com/lilboards/lilboards"
             target="_blank"
             rel="noopener noreferrer"
             title="GitHub"

--- a/src/pages/Support/Support.tsx
+++ b/src/pages/Support/Support.tsx
@@ -34,7 +34,7 @@ export default function Support() {
       </Typography>
 
       <Typography paragraph component="section">
-        Want to sponsor this project?
+        Want to sponsor the project?
         <ul>
           {sponsorLinks.map(({ text, href }, index) => (
             <li key={index}>


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(Header): change the SupportIcon to the HelpIcon

## What is the current behavior?

- Header shows SupportIcon
- GitHub uses short link

## What is the new behavior?

- Header shows HelpIcon
- GitHub no longer uses short link
- Minor copy improvements in Support page

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation