### PR TITLE
perf(redux): optimize selectors with memoization

### DIFF
--- a/src/components/BoardControls/AddColumn.tsx
+++ b/src/components/BoardControls/AddColumn.tsx
@@ -1,5 +1,5 @@
 import { generateId, logEvent } from '../../firebase';
-import { useDispatch, useIsAdmin, useSelector } from '../../hooks';
+import { useDispatch, useGetUserId, useIsAdmin } from '../../hooks';
 import { actions } from '../../store';
 import type { Column, Id } from '../../types';
 import AddButton from '../AddButton';
@@ -11,7 +11,7 @@ interface Props {
 export default function AddColumn(props: Props) {
   const dispatch = useDispatch();
   const canEdit = useIsAdmin(props.boardId);
-  const userId = useSelector((state) => state.user.id);
+  const userId = useGetUserId();
 
   if (!canEdit) {
     return null;

--- a/src/components/BoardControls/Export.test.tsx
+++ b/src/components/BoardControls/Export.test.tsx
@@ -8,7 +8,6 @@ const writeText = jest.fn();
 
 beforeAll(() => {
   (navigator as any).clipboard = { writeText };
-  jest.useFakeTimers();
 });
 
 beforeEach(() => {
@@ -17,7 +16,6 @@ beforeEach(() => {
 
 afterAll(() => {
   (navigator as any).clipboard = clipboard;
-  jest.useRealTimers();
 });
 
 it('copies empty markdown to clipboard', () => {

--- a/src/components/BoardControls/Export.tsx
+++ b/src/components/BoardControls/Export.tsx
@@ -1,13 +1,20 @@
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
+import { createSelector } from '@reduxjs/toolkit';
 
 import { logEvent } from '../../firebase';
 import { useSelector } from '../../hooks';
+import type { RootState } from '../../types';
 import { transformToMarkdown } from './utils';
 
+const selectColumns = createSelector(
+  (state: RootState) => state.columns,
+  (columns) => columns
+);
+
 export default function Export() {
-  const columns = useSelector((state) => state.columns);
+  const columns = useSelector(selectColumns);
   const items = useSelector((state) => state.items);
 
   async function copyBoardMarkdownToClipboard() {

--- a/src/components/Boards/AddBoard.tsx
+++ b/src/components/Boards/AddBoard.tsx
@@ -1,12 +1,12 @@
 import AddButton from '../../components/AddButton';
 import { generateId, logEvent, saveUserBoardId } from '../../firebase';
-import { useDispatch, useSelector } from '../../hooks';
+import { useDispatch, useGetUserId } from '../../hooks';
 import { actions } from '../../store';
 import type { Board } from '../../types';
 
 export default function AddBoard() {
   const dispatch = useDispatch();
-  const userId = useSelector((state) => state.user.id);
+  const userId = useGetUserId();
 
   function addBoard() {
     const board: Board = {

--- a/src/components/Column/Column.tsx
+++ b/src/components/Column/Column.tsx
@@ -1,8 +1,9 @@
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
+import { createSelector } from '@reduxjs/toolkit';
 
 import { useSelector } from '../../hooks';
-import type { Id } from '../../types';
+import type { Id, RootState } from '../../types';
 import Items from '../Items';
 import ColumnName from './ColumnName';
 
@@ -12,8 +13,14 @@ interface Props {
   columnIndex: number;
 }
 
+const selectColumn = createSelector(
+  (state: RootState) => state.columns,
+  (_: unknown, columnId: Id) => columnId,
+  (columns, columnId) => columns[columnId]
+);
+
 export default function Column(props: Props) {
-  const column = useSelector((state) => state.columns[props.columnId]);
+  const column = useSelector((state) => selectColumn(state, props.columnId));
 
   if (!column) {
     return null;

--- a/src/components/Column/ColumnName.tsx
+++ b/src/components/Column/ColumnName.tsx
@@ -1,13 +1,17 @@
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import { createSelector } from '@reduxjs/toolkit';
 import { type ChangeEvent, useState } from 'react';
 
 import DeleteDialog from '../../components/DeleteDialog';
 import { logEvent } from '../../firebase';
-import { useDispatch, useGetUserId, useSelector } from '../../hooks';
+import {
+  useDispatch,
+  useGetItemIds,
+  useGetUserId,
+  useSelector,
+} from '../../hooks';
 import { actions } from '../../store';
-import type { Id, RootState } from '../../types';
+import type { Id } from '../../types';
 import CloseButton from '../CloseButton';
 
 interface Props {
@@ -17,12 +21,6 @@ interface Props {
   placeholder: string;
 }
 
-const selectItemIds = createSelector(
-  (state: RootState) => state.columns,
-  (_: unknown, columnId: Id) => columnId,
-  (columns, columnId) => (columns[columnId] || {}).itemIds || []
-);
-
 export default function ColumnName(props: Props) {
   const dispatch = useDispatch();
   const isEditing = useSelector(
@@ -31,7 +29,7 @@ export default function ColumnName(props: Props) {
   const readOnly = useSelector(
     (state) => (state.boards[props.boardId] || {}).createdBy !== state.user.id
   );
-  const itemIds = useSelector((state) => selectItemIds(state, props.columnId));
+  const itemIds = useGetItemIds(props.columnId);
   const userId = useGetUserId();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const columnName = props.name || props.placeholder;

--- a/src/components/Column/ColumnName.tsx
+++ b/src/components/Column/ColumnName.tsx
@@ -1,12 +1,13 @@
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import { createSelector } from '@reduxjs/toolkit';
 import { type ChangeEvent, useState } from 'react';
 
 import DeleteDialog from '../../components/DeleteDialog';
 import { logEvent } from '../../firebase';
 import { useDispatch, useSelector } from '../../hooks';
 import { actions } from '../../store';
-import type { Id } from '../../types';
+import type { Id, RootState } from '../../types';
 import CloseButton from '../CloseButton';
 
 interface Props {
@@ -16,6 +17,12 @@ interface Props {
   placeholder: string;
 }
 
+const selectItemIds = createSelector(
+  (state: RootState) => state.columns,
+  (_: unknown, columnId: Id) => columnId,
+  (columns, columnId) => (columns[columnId] || {}).itemIds || []
+);
+
 export default function ColumnName(props: Props) {
   const dispatch = useDispatch();
   const isEditing = useSelector(
@@ -24,9 +31,7 @@ export default function ColumnName(props: Props) {
   const readOnly = useSelector(
     (state) => (state.boards[props.boardId] || {}).createdBy !== state.user.id
   );
-  const itemIds = useSelector(
-    (state) => (state.columns[props.columnId] || {}).itemIds || []
-  );
+  const itemIds = useSelector((state) => selectItemIds(state, props.columnId));
   const userId = useSelector((state) => state.user.id);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const columnName = props.name || props.placeholder;

--- a/src/components/Column/ColumnName.tsx
+++ b/src/components/Column/ColumnName.tsx
@@ -5,7 +5,7 @@ import { type ChangeEvent, useState } from 'react';
 
 import DeleteDialog from '../../components/DeleteDialog';
 import { logEvent } from '../../firebase';
-import { useDispatch, useSelector } from '../../hooks';
+import { useDispatch, useGetUserId, useSelector } from '../../hooks';
 import { actions } from '../../store';
 import type { Id, RootState } from '../../types';
 import CloseButton from '../CloseButton';
@@ -32,7 +32,7 @@ export default function ColumnName(props: Props) {
     (state) => (state.boards[props.boardId] || {}).createdBy !== state.user.id
   );
   const itemIds = useSelector((state) => selectItemIds(state, props.columnId));
-  const userId = useSelector((state) => state.user.id);
+  const userId = useGetUserId();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const columnName = props.name || props.placeholder;
 

--- a/src/components/Columns/Columns.tsx
+++ b/src/components/Columns/Columns.tsx
@@ -1,7 +1,8 @@
 import Grid from '@mui/material/Grid';
+import { createSelector } from '@reduxjs/toolkit';
 
 import { useSelector } from '../../hooks';
-import type { Id } from '../../types';
+import type { Id, RootState } from '../../types';
 import Column from '../Column';
 import DragDropContainer from './DragDropContainer';
 import { useColumns, useItems, useLikes } from './hooks';
@@ -10,11 +11,17 @@ interface Props {
   boardId: Id;
 }
 
+const selectColumnIds = createSelector(
+  (state: RootState) => state.columns,
+  (columns) => Object.keys(columns)
+);
+
 export default function Columns(props: Props) {
   useColumns(props.boardId);
   useItems(props.boardId);
   useLikes(props.boardId);
-  const columnIds = useSelector((state) => Object.keys(state.columns));
+
+  const columnIds = useSelector(selectColumnIds);
 
   return (
     <Grid container spacing={2} wrap="nowrap">

--- a/src/components/Columns/DragDropContainer.tsx
+++ b/src/components/Columns/DragDropContainer.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import type { DropResult } from 'react-beautiful-dnd';
 import { DragDropContext } from 'react-beautiful-dnd';
 
-import { useDispatch, useSelector } from '../../hooks';
+import { useDispatch, useGetUserId, useSelector } from '../../hooks';
 import { actions } from '../../store';
 import type { Id } from '../../types';
 import { combine, reorder } from './utils';
@@ -17,7 +17,7 @@ export default function DragDropContainer(props: Props) {
   const columns = useSelector((state) => state.columns);
   const items = useSelector((state) => state.items);
   const likes = useSelector((state) => state.likes.items);
-  const userId = useSelector((state) => state.user.id);
+  const userId = useGetUserId();
 
   /* istanbul ignore next */
   function handleDragEnd(result: DropResult) {

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -5,7 +5,7 @@ import InputBase from '@mui/material/InputBase';
 import type { ChangeEvent, CSSProperties } from 'react';
 
 import { logEvent } from '../../firebase';
-import { useDispatch, useSelector } from '../../hooks';
+import { useDispatch, useGetUserId, useSelector } from '../../hooks';
 import { actions } from '../../store';
 import type { Id } from '../../types';
 import Delete from './Delete';
@@ -24,7 +24,7 @@ export default function Item(props: Props) {
   const isEditing = useSelector(
     (state) => state.user.editing.itemId === props.itemId
   );
-  const userId = useSelector((state) => state.user.id);
+  const userId = useGetUserId();
 
   if (!item) {
     return null;

--- a/src/components/Item/LikeButton.tsx
+++ b/src/components/Item/LikeButton.tsx
@@ -3,7 +3,12 @@ import ThumbUpOutlinedIcon from '@mui/icons-material/ThumbUpOutlined';
 import IconButton from '@mui/material/IconButton';
 
 import { logEvent } from '../../firebase';
-import { useDispatch, useMaxLikes, useSelector } from '../../hooks';
+import {
+  useDispatch,
+  useGetUserId,
+  useMaxLikes,
+  useSelector,
+} from '../../hooks';
 import { actions } from '../../store';
 import type { Id } from '../../types';
 
@@ -14,7 +19,7 @@ interface Props {
 
 export default function LikeButton(props: Props) {
   const dispatch = useDispatch();
-  const userId = useSelector((state) => state.user.id);
+  const userId = useGetUserId();
   const itemText = useSelector(
     (state) => state.items[props.itemId]?.text || ''
   );

--- a/src/components/Item/LikeButton.tsx
+++ b/src/components/Item/LikeButton.tsx
@@ -5,6 +5,7 @@ import IconButton from '@mui/material/IconButton';
 import { logEvent } from '../../firebase';
 import {
   useDispatch,
+  useGetLikes,
   useGetUserId,
   useMaxLikes,
   useSelector,
@@ -23,7 +24,7 @@ export default function LikeButton(props: Props) {
   const itemText = useSelector(
     (state) => state.items[props.itemId]?.text || ''
   );
-  const likes = useSelector((state) => state.likes.items[props.itemId] || {});
+  const likes = useGetLikes(props.itemId);
   const isLikedByUser = likes[userId];
   const totalLikes = useSelector((state) =>
     Object.values(state.likes.items).reduce(

--- a/src/components/Item/Likes.tsx
+++ b/src/components/Item/Likes.tsx
@@ -1,6 +1,6 @@
 import Box from '@mui/material/Box';
 
-import { useSelector } from '../../hooks';
+import { useGetLikes } from '../../hooks';
 import type { Id } from '../../types';
 import { countObject } from '../../utils';
 import LikeButton from './LikeButton';
@@ -11,7 +11,7 @@ interface Props {
 }
 
 export default function Likes(props: Props) {
-  const likes = useSelector((state) => state.likes.items[props.itemId] || {});
+  const likes = useGetLikes(props.itemId);
   const likesCount = countObject(likes);
 
   return (

--- a/src/components/Items/DroppableItems.tsx
+++ b/src/components/Items/DroppableItems.tsx
@@ -1,7 +1,7 @@
 import Box from '@mui/material/Box';
 import { Droppable } from 'react-beautiful-dnd';
 
-import { useSelector } from '../../hooks';
+import { useGetItemIds } from '../../hooks';
 import type { Id } from '../../types';
 import InnerList from './InnerList';
 import { getDroppableBackgroundColor } from './styles';
@@ -12,9 +12,7 @@ interface Props {
 }
 
 export default function DroppableItems(props: Props) {
-  const itemIds = useSelector(
-    (state) => (state.columns[props.columnId] || {}).itemIds || []
-  );
+  const itemIds = useGetItemIds(props.columnId);
 
   return (
     <Droppable droppableId={props.columnId} isCombineEnabled>

--- a/src/components/Items/Items.tsx
+++ b/src/components/Items/Items.tsx
@@ -2,7 +2,7 @@ import AddIcon from '@mui/icons-material/Add';
 import Button from '@mui/material/Button';
 
 import { generateId, logEvent } from '../../firebase';
-import { useDispatch, useSelector } from '../../hooks';
+import { useDispatch, useGetUserId } from '../../hooks';
 import { actions } from '../../store';
 import type { Id, Item } from '../../types';
 import DroppableItems from './DroppableItems';
@@ -14,7 +14,7 @@ interface Props {
 
 export default function Items(props: Props) {
   const dispatch = useDispatch();
-  const userId = useSelector((state) => state.user.id);
+  const userId = useGetUserId();
 
   function addItem() {
     const item: Item = {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,6 +1,7 @@
 export * from './useAuth';
 export * from './useDispatch';
 export * from './useGetItemIds';
+export * from './useGetLikes';
 export * from './useGetUserId';
 export * from './useIsAdmin';
 export * from './useMaxLikes';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './useAuth';
 export * from './useDispatch';
+export * from './useGetUserId';
 export * from './useIsAdmin';
 export * from './useMaxLikes';
 export * from './useSelector';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './useAuth';
 export * from './useDispatch';
+export * from './useGetItemIds';
 export * from './useGetUserId';
 export * from './useIsAdmin';
 export * from './useMaxLikes';

--- a/src/hooks/useAuth.test.tsx
+++ b/src/hooks/useAuth.test.tsx
@@ -1,14 +1,12 @@
 import { renderHook } from '@testing-library/react';
 import type { Unsubscribe, User } from 'firebase/auth';
-import type { ReactNode } from 'react';
-import { Provider } from 'react-redux';
 
 import {
   USER_TEST_EMAIL as userEmail,
   USER_TEST_ID as userId,
 } from '../constants/test';
 import { logEvent, onAuthStateChanged, signInAnonymously } from '../firebase';
-import { store } from '../utils/test';
+import { store, wrapper } from '../utils/test';
 import { useAuth } from './useAuth';
 
 jest.mock('../firebase', () => ({
@@ -18,10 +16,6 @@ jest.mock('../firebase', () => ({
 }));
 
 const mockedOnAuthStateChanged = jest.mocked(onAuthStateChanged);
-
-function wrapper(props: { children?: ReactNode }) {
-  return <Provider store={store}>{props.children}</Provider>;
-}
 
 beforeEach(() => {
   jest.resetAllMocks();

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -5,11 +5,12 @@ import { actions } from '../store';
 import { useDispatch } from '.';
 
 /**
- * User authentication hook.
+ * User authentication.
  *
  * @param shouldSignInAnonymously - Should user sign in anonymously.
+ * @returns - If authentication has finished.
  */
-export function useAuth(shouldSignInAnonymously = false) {
+export function useAuth(shouldSignInAnonymously = false): boolean {
   const dispatch = useDispatch();
   const [isLoaded, setIsLoaded] = useState(false);
 

--- a/src/hooks/useGetItemIds.test.ts
+++ b/src/hooks/useGetItemIds.test.ts
@@ -16,8 +16,8 @@ describe.each([{}, { columns: {} }, { columns: { [COLUMN_TEST_ID]: {} } }])(
   }
 );
 
-describe('when item exists', () => {
-  it('returns item id', () => {
+describe('when column exists', () => {
+  it('returns item ids', () => {
     updateStore.withColumn();
     const { result } = renderHook(() => useGetItemIds(COLUMN_TEST_ID), {
       wrapper,

--- a/src/hooks/useGetItemIds.test.ts
+++ b/src/hooks/useGetItemIds.test.ts
@@ -4,17 +4,14 @@ import { COLUMN_TEST_ID, ITEM_TEST_ID } from '../constants/test';
 import { updateStore, wrapper } from '../utils/test';
 import { useGetItemIds } from './useGetItemIds';
 
-describe.each([{}, { columns: {} }, { columns: { [COLUMN_TEST_ID]: {} } }])(
-  'when state is %j',
-  (state) => {
-    it('returns empty array', () => {
-      const { result } = renderHook(() => useGetItemIds(COLUMN_TEST_ID), {
-        wrapper,
-      });
-      expect(result.current).toEqual([]);
+describe('when state is empty', () => {
+  it('returns empty array', () => {
+    const { result } = renderHook(() => useGetItemIds(COLUMN_TEST_ID), {
+      wrapper,
     });
-  }
-);
+    expect(result.current).toEqual([]);
+  });
+});
 
 describe('when column exists', () => {
   it('returns item ids', () => {

--- a/src/hooks/useGetItemIds.test.ts
+++ b/src/hooks/useGetItemIds.test.ts
@@ -1,0 +1,27 @@
+import { renderHook } from '@testing-library/react';
+
+import { COLUMN_TEST_ID, ITEM_TEST_ID } from '../constants/test';
+import { updateStore, wrapper } from '../utils/test';
+import { useGetItemIds } from './useGetItemIds';
+
+describe.each([{}, { columns: {} }, { columns: { [COLUMN_TEST_ID]: {} } }])(
+  'when state is %j',
+  (state) => {
+    it('returns empty array', () => {
+      const { result } = renderHook(() => useGetItemIds(COLUMN_TEST_ID), {
+        wrapper,
+      });
+      expect(result.current).toEqual([]);
+    });
+  }
+);
+
+describe('when item exists', () => {
+  it('returns item id', () => {
+    updateStore.withColumn();
+    const { result } = renderHook(() => useGetItemIds(COLUMN_TEST_ID), {
+      wrapper,
+    });
+    expect(result.current).toEqual([ITEM_TEST_ID]);
+  });
+});

--- a/src/hooks/useGetItemIds.ts
+++ b/src/hooks/useGetItemIds.ts
@@ -1,0 +1,17 @@
+import { createSelector } from '@reduxjs/toolkit';
+
+import type { Id, RootState } from '../types';
+import { useSelector } from './useSelector';
+
+const selectItemIds = createSelector(
+  (state: RootState) => state.columns,
+  (_: unknown, columnId: Id) => columnId,
+  (columns, columnId) => (columns[columnId] || {}).itemIds || []
+);
+
+/**
+ * Get item ids.
+ */
+export function useGetItemIds(columnId: Id) {
+  return useSelector((state) => selectItemIds(state, columnId));
+}

--- a/src/hooks/useGetItemIds.ts
+++ b/src/hooks/useGetItemIds.ts
@@ -10,8 +10,10 @@ const selectItemIds = createSelector(
 );
 
 /**
- * Get item ids.
+ * Get column item ids.
+ *
+ * @param columnId - Column id.
  */
-export function useGetItemIds(columnId: Id) {
+export function useGetItemIds(columnId: Id): Id[] {
   return useSelector((state) => selectItemIds(state, columnId));
 }

--- a/src/hooks/useGetLikes.test.ts
+++ b/src/hooks/useGetLikes.test.ts
@@ -4,17 +4,14 @@ import { ITEM_TEST_ID, USER_TEST_ID } from '../constants/test';
 import { updateStore, wrapper } from '../utils/test';
 import { useGetLikes } from './useGetLikes';
 
-describe.each([{}, { likes: {} }, { likes: { items: {} } }])(
-  'when state is %j',
-  (state) => {
-    it('returns empty array', () => {
-      const { result } = renderHook(() => useGetLikes(ITEM_TEST_ID), {
-        wrapper,
-      });
-      expect(result.current).toEqual({});
+describe('when state is empty', () => {
+  it('returns empty array', () => {
+    const { result } = renderHook(() => useGetLikes(ITEM_TEST_ID), {
+      wrapper,
     });
-  }
-);
+    expect(result.current).toEqual({});
+  });
+});
 
 describe('when item exists', () => {
   it('returns likes', () => {

--- a/src/hooks/useGetLikes.test.ts
+++ b/src/hooks/useGetLikes.test.ts
@@ -1,0 +1,28 @@
+import { renderHook } from '@testing-library/react';
+
+import { ITEM_TEST_ID, USER_TEST_ID } from '../constants/test';
+import { updateStore, wrapper } from '../utils/test';
+import { useGetLikes } from './useGetLikes';
+
+describe.each([{}, { likes: {} }, { likes: { items: {} } }])(
+  'when state is %j',
+  (state) => {
+    it('returns empty array', () => {
+      const { result } = renderHook(() => useGetLikes(ITEM_TEST_ID), {
+        wrapper,
+      });
+      expect(result.current).toEqual({});
+    });
+  }
+);
+
+describe('when item exists', () => {
+  it('returns likes', () => {
+    updateStore.withColumn();
+    updateStore.withLike();
+    const { result } = renderHook(() => useGetLikes(ITEM_TEST_ID), {
+      wrapper,
+    });
+    expect(result.current).toEqual({ [USER_TEST_ID]: true });
+  });
+});

--- a/src/hooks/useGetLikes.ts
+++ b/src/hooks/useGetLikes.ts
@@ -1,0 +1,17 @@
+import { createSelector } from '@reduxjs/toolkit';
+
+import type { Id, RootState } from '../types';
+import { useSelector } from './useSelector';
+
+const selectLikes = createSelector(
+  (state: RootState) => state.likes.items,
+  (_: unknown, itemId: Id) => itemId,
+  (items, itemId) => items[itemId] || {}
+);
+
+/**
+ * Get likes.
+ */
+export function useGetLikes(itemId: Id) {
+  return useSelector((state) => selectLikes(state, itemId));
+}

--- a/src/hooks/useGetLikes.ts
+++ b/src/hooks/useGetLikes.ts
@@ -10,7 +10,9 @@ const selectLikes = createSelector(
 );
 
 /**
- * Get likes.
+ * Get item likes.
+ *
+ * @param itemId - Item id.
  */
 export function useGetLikes(itemId: Id) {
   return useSelector((state) => selectLikes(state, itemId));

--- a/src/hooks/useGetUserId.test.ts
+++ b/src/hooks/useGetUserId.test.ts
@@ -3,7 +3,7 @@ import { renderHook } from '@testing-library/react';
 import { updateStore, wrapper } from '../utils/test';
 import { useGetUserId } from './useGetUserId';
 
-describe.each([{}, { user: {} }])('when state is %j', (state) => {
+describe('when state is empty', () => {
   it('returns empty string', () => {
     const { result } = renderHook(() => useGetUserId(), { wrapper });
     expect(result.current).toBe('');

--- a/src/hooks/useGetUserId.test.ts
+++ b/src/hooks/useGetUserId.test.ts
@@ -1,0 +1,19 @@
+import { renderHook } from '@testing-library/react';
+
+import { updateStore, wrapper } from '../utils/test';
+import { useGetUserId } from './useGetUserId';
+
+describe.each([{}, { user: {} }])('when state is %p', (state) => {
+  it('returns empty string', () => {
+    const { result } = renderHook(() => useGetUserId(), { wrapper });
+    expect(result.current).toBe('');
+  });
+});
+
+describe('when user exists', () => {
+  it('returns user id', () => {
+    const user = updateStore.withUser();
+    const { result } = renderHook(() => useGetUserId(), { wrapper });
+    expect(result.current).toBe(user.id);
+  });
+});

--- a/src/hooks/useGetUserId.test.ts
+++ b/src/hooks/useGetUserId.test.ts
@@ -3,7 +3,7 @@ import { renderHook } from '@testing-library/react';
 import { updateStore, wrapper } from '../utils/test';
 import { useGetUserId } from './useGetUserId';
 
-describe.each([{}, { user: {} }])('when state is %p', (state) => {
+describe.each([{}, { user: {} }])('when state is %j', (state) => {
   it('returns empty string', () => {
     const { result } = renderHook(() => useGetUserId(), { wrapper });
     expect(result.current).toBe('');

--- a/src/hooks/useGetUserId.ts
+++ b/src/hooks/useGetUserId.ts
@@ -1,6 +1,6 @@
 import { createSelector } from '@reduxjs/toolkit';
 
-import type { RootState } from '../types';
+import type { Id, RootState } from '../types';
 import { useSelector } from './useSelector';
 
 const selectUserId = createSelector(
@@ -11,6 +11,6 @@ const selectUserId = createSelector(
 /**
  * Get user id.
  */
-export function useGetUserId() {
+export function useGetUserId(): Id {
   return useSelector(selectUserId);
 }

--- a/src/hooks/useGetUserId.ts
+++ b/src/hooks/useGetUserId.ts
@@ -1,0 +1,16 @@
+import { createSelector } from '@reduxjs/toolkit';
+
+import type { RootState } from '../types';
+import { useSelector } from './useSelector';
+
+const selectUserId = createSelector(
+  (state: RootState) => state.user,
+  (user) => user?.id || ''
+);
+
+/**
+ * Get user id.
+ */
+export function useGetUserId() {
+  return useSelector(selectUserId);
+}

--- a/src/hooks/useIsAdmin.ts
+++ b/src/hooks/useIsAdmin.ts
@@ -3,8 +3,10 @@ import { useSelector } from './useSelector';
 
 /**
  * Is admin hook.
+ *
+ * @param boardId - Board id.
  */
-export function useIsAdmin(boardId: Id) {
+export function useIsAdmin(boardId: Id): boolean {
   return useSelector((state) => {
     if (!boardId) {
       return false;

--- a/src/hooks/useMaxLikes.test.ts
+++ b/src/hooks/useMaxLikes.test.ts
@@ -1,91 +1,46 @@
 import { renderHook } from '@testing-library/react';
 
 import { BOARD_TEST_ID } from '../constants/test';
-import type { RootState } from '../types';
-import { useSelector } from '.';
+import { updateStore, wrapper } from '../utils/test';
 import { DEFAULT_MAX_LIKES, useMaxLikes } from './useMaxLikes';
 
-jest.mock('.', () => ({
-  useSelector: jest.fn(),
-}));
-
-const mockedUseSelector = jest.mocked(useSelector);
-
-describe('when boards are empty', () => {
-  const state = {
-    boards: {},
-  } as RootState;
-
+describe('when state is empty', () => {
   it('returns default max likes', () => {
-    mockedUseSelector.mockImplementationOnce((callback) => callback(state));
-    const { result } = renderHook(() => useMaxLikes(BOARD_TEST_ID));
-    expect(result.current).toBe(DEFAULT_MAX_LIKES);
-  });
-});
-
-describe('when board is undefined', () => {
-  const state = {
-    boards: {
-      [`${BOARD_TEST_ID}2`]: {
-        maxLikes: DEFAULT_MAX_LIKES - 1,
-      },
-    },
-  } as RootState;
-
-  it('returns default max likes', () => {
-    mockedUseSelector.mockImplementationOnce((callback) => callback(state));
-    const { result } = renderHook(() => useMaxLikes(BOARD_TEST_ID));
+    const { result } = renderHook(() => useMaxLikes(BOARD_TEST_ID), {
+      wrapper,
+    });
     expect(result.current).toBe(DEFAULT_MAX_LIKES);
   });
 });
 
 describe('when maxLikes is undefined', () => {
-  const maxLikes = undefined;
-  const state = {
-    boards: {
-      [BOARD_TEST_ID]: {
-        maxLikes,
-      },
-    },
-  } as unknown as RootState;
-
   it('returns default max likes', () => {
-    mockedUseSelector.mockImplementationOnce((callback) => callback(state));
-    const { result } = renderHook(() => useMaxLikes(BOARD_TEST_ID));
+    updateStore.withBoard();
+    const { result } = renderHook(() => useMaxLikes(BOARD_TEST_ID), {
+      wrapper,
+    });
     expect(result.current).toBe(DEFAULT_MAX_LIKES);
   });
 });
 
 describe('when maxLikes is valid', () => {
-  const maxLikes = DEFAULT_MAX_LIKES + 1;
-  const state = {
-    boards: {
-      [BOARD_TEST_ID]: {
-        maxLikes,
-      },
-    },
-  } as unknown as RootState;
-
   it('returns max likes', () => {
-    mockedUseSelector.mockImplementationOnce((callback) => callback(state));
-    const { result } = renderHook(() => useMaxLikes(BOARD_TEST_ID));
+    const maxLikes = DEFAULT_MAX_LIKES + 1;
+    updateStore.withBoard({ maxLikes });
+    const { result } = renderHook(() => useMaxLikes(BOARD_TEST_ID), {
+      wrapper,
+    });
     expect(result.current).toBe(maxLikes);
   });
 });
 
 describe('when maxLikes is 0', () => {
-  const maxLikes = 0;
-  const state = {
-    boards: {
-      [BOARD_TEST_ID]: {
-        maxLikes,
-      },
-    },
-  } as unknown as RootState;
-
   it('returns 0', () => {
-    mockedUseSelector.mockImplementationOnce((callback) => callback(state));
-    const { result } = renderHook(() => useMaxLikes(BOARD_TEST_ID));
+    const maxLikes = 0;
+    updateStore.withBoard({ maxLikes });
+    const { result } = renderHook(() => useMaxLikes(BOARD_TEST_ID), {
+      wrapper,
+    });
     expect(result.current).toBe(maxLikes);
   });
 });

--- a/src/hooks/useMaxLikes.ts
+++ b/src/hooks/useMaxLikes.ts
@@ -1,16 +1,22 @@
-import type { Id } from '../types';
+import { createSelector } from '@reduxjs/toolkit';
+
+import type { Id, RootState } from '../types';
 import { useSelector } from '.';
 
 export const DEFAULT_MAX_LIKES = 5;
 
+const selectMaxLikes = createSelector(
+  (state: RootState) => state.boards,
+  (_: unknown, boardId: Id) => boardId,
+  (boards, boardId) => (boards[boardId] || {}).maxLikes
+);
+
 /**
- * Max likes hook.
+ * Get board max likes.
  *
  * @param boardId - Board id.
  */
 export function useMaxLikes(boardId: Id): number {
-  const maxLikes = useSelector(
-    (state) => (state.boards[boardId] || {}).maxLikes
-  );
+  const maxLikes = useSelector((state) => selectMaxLikes(state, boardId));
   return maxLikes ?? DEFAULT_MAX_LIKES;
 }

--- a/src/hooks/useSetDocumentTitle.ts
+++ b/src/hooks/useSetDocumentTitle.ts
@@ -1,9 +1,9 @@
 import { useEffect } from 'react';
 
 /**
- * Set document title hook.
+ * Set document title.
  */
-export function useSetDocumentTitle(title: string) {
+export function useSetDocumentTitle(title: string): void {
   useEffect(() => {
     document.title = title;
   });

--- a/src/pages/Boards/BoardCard.tsx
+++ b/src/pages/Boards/BoardCard.tsx
@@ -9,7 +9,7 @@ import { Link } from 'react-router-dom';
 
 import DeleteDialog from '../../components/DeleteDialog';
 import { logEvent } from '../../firebase';
-import { useDispatch, useSelector } from '../../hooks';
+import { useDispatch, useGetUserId, useSelector } from '../../hooks';
 import { actions } from '../../store';
 import type { Id } from '../../types';
 
@@ -23,7 +23,7 @@ export default function BoardCard(props: Props) {
   const isEditing = useSelector(
     (state) => state.user.editing.boardId === props.boardId
   );
-  const userId = useSelector((state) => state.user.id);
+  const userId = useGetUserId();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   if (!board) {

--- a/src/pages/Boards/BoardCards.tsx
+++ b/src/pages/Boards/BoardCards.tsx
@@ -1,20 +1,26 @@
 import Grid from '@mui/material/Grid';
+import { createSelector } from '@reduxjs/toolkit';
 
 import { useSelector } from '../../hooks';
-import { SortBy, SortOrder } from '../../types';
+import { RootState, SortBy, SortOrder } from '../../types';
 import { sort } from '../../utils';
 import BoardCard from './BoardCard';
 
-export default function BoardCards() {
-  const boardIds = useSelector((state) => {
-    const boards = Object.keys(state.boards).map((id) => ({
-      ...state.boards[id],
+const selectBoardIds = createSelector(
+  (state: RootState) => state.boards,
+  (boards) => {
+    const boardsWithId = Object.keys(boards).map((id) => ({
+      ...boards[id],
       id,
     }));
-    return sort(boards, SortBy.createdAt, SortOrder.Descending).map(
+    return sort(boardsWithId, SortBy.createdAt, SortOrder.Descending).map(
       (board) => board.id
     );
-  });
+  }
+);
+
+export default function BoardCards() {
+  const boardIds = useSelector(selectBoardIds);
 
   if (!boardIds.length) {
     return null;

--- a/src/pages/Boards/Boards.tsx
+++ b/src/pages/Boards/Boards.tsx
@@ -1,13 +1,14 @@
 import Typography from '@mui/material/Typography';
 
 import AddBoard from '../../components/Boards/AddBoard';
-import { useDispatch, useSelector, useSetDocumentTitle } from '../../hooks';
+import { useDispatch, useGetUserId, useSetDocumentTitle } from '../../hooks';
 import BoardCards from './BoardCards';
 import { useBoards } from './hooks';
 
 export default function Boards() {
   const dispatch = useDispatch();
-  const userId = useSelector((state) => state.user.id);
+  const userId = useGetUserId();
+
   useBoards(dispatch, userId);
   useSetDocumentTitle('Boards');
 

--- a/src/utils/test.tsx
+++ b/src/utils/test.tsx
@@ -21,7 +21,7 @@ function noop() {}
 
 export let router: ReturnType<typeof createMemoryRouter>;
 
-function wrapper(props: { children?: ReactNode }) {
+export function wrapper(props: { children?: ReactNode }) {
   const routes = [
     {
       path: '/',


### PR DESCRIPTION
## What is the motivation for this pull request?

perf(redux): optimize selectors with memoization

## What is the current behavior?

Components and hooks calling `useSelector` are not memoized:

> Selector unknown returned a different result when called with the same parameters. This can lead to unnecessary rerenders.
> Selectors that return a new reference (such as an object or an array) should be memoized: https://redux.js.org/usage/deriving-data-selectors#optimizing-selectors-with-memoization

## What is the new behavior?

Components and hooks calling `useSelector` are memoized

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation