### PR TITLE
fix(BoardControls): update Export to copy columns with default name

### DIFF
--- a/src/components/BoardControls/utils/__snapshots__/transform.test.ts.snap
+++ b/src/components/BoardControls/utils/__snapshots__/transform.test.ts.snap
@@ -43,7 +43,7 @@ exports[`[Function transformToMarkdown] transforms columns with no items 1`] = `
 `;
 
 exports[`[Function transformToMarkdown] transforms columns with no name 1`] = `
-"|  |  |
+"| Column 1 | Column 2 |
 | --- | --- |
 "
 `;
@@ -125,8 +125,8 @@ Array [
 exports[`[Function transformToRows] transforms columns with no name 1`] = `
 Array [
   Array [
-    "",
-    "",
+    "Column 1",
+    "Column 2",
   ],
 ]
 `;

--- a/src/components/BoardControls/utils/transform.ts
+++ b/src/components/BoardControls/utils/transform.ts
@@ -8,12 +8,15 @@ const NEWLINE = '\n';
 export function transformToRows(columns: Columns, items: Items) {
   const columnValues = Object.values(columns);
   const columnsLength = columnValues.length;
+
   if (!columnsLength) {
     return [];
   }
-  const rows: string[][] = [];
 
-  const headers = columnValues.map((column) => column.name);
+  const rows: string[][] = [];
+  const headers = columnValues.map(
+    (column, index) => column.name || `Column ${index + 1}`
+  );
   rows.push(headers);
 
   columnValues.forEach(({ itemIds }, columnIndex) => {
@@ -36,6 +39,7 @@ export function transformToRows(columns: Columns, items: Items) {
  */
 export function transformToMarkdown(columns: Columns, items: Items): string {
   const rows = transformToRows(columns, items);
+
   if (!rows.length) {
     return '';
   }


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(BoardControls): update Export to copy columns with default name

## What is the current behavior?

If column name is blank, export to markdown column is also blank

## What is the new behavior?

If column name is blank, export to markdown column is renders default name (e.g., `Column 1`)

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation