### PR TITLE
fix(BoardControls): replace menu icon with more icon

### DIFF
--- a/src/components/BoardControls/BoardControls.test.tsx
+++ b/src/components/BoardControls/BoardControls.test.tsx
@@ -76,7 +76,7 @@ describe('mobile', () => {
   it('toggles board controls', async () => {
     renderWithProviders(<BoardControls boardId={board.id} />);
     expect(screen.getAllByLabelText('Hide Likes')).toHaveLength(1);
-    fireEvent.click(screen.getByLabelText('Toggle board controls'));
+    fireEvent.click(screen.getByLabelText('Board Controls'));
     expect(screen.getAllByLabelText('Hide Likes')).toHaveLength(2);
     // eslint-disable-next-line testing-library/no-node-access
     fireEvent.click(screen.getByRole('presentation').firstChild!);

--- a/src/components/BoardControls/BoardControls.tsx
+++ b/src/components/BoardControls/BoardControls.tsx
@@ -1,4 +1,4 @@
-import MenuIcon from '@mui/icons-material/Menu';
+import MoreIcon from '@mui/icons-material/MoreHoriz';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import Popover from '@mui/material/Popover';
@@ -55,11 +55,11 @@ export default function BoardControls(props: Props) {
       <Box sx={{ display: { xs: 'block', md: 'none' } }}>
         <IconButton
           aria-describedby={popoverId}
-          aria-label="Toggle board controls"
+          aria-label="Board Controls"
           onClick={handleClick}
-          title="Toggle board controls"
+          title="Board Controls"
         >
-          <MenuIcon />
+          <MoreIcon />
         </IconButton>
 
         <Popover

--- a/src/pages/Support/Support.tsx
+++ b/src/pages/Support/Support.tsx
@@ -34,7 +34,7 @@ export default function Support() {
       </Typography>
 
       <Typography paragraph component="section">
-        Want to sponsor the project?
+        Want to support the maintainer?
         <ul>
           {sponsorLinks.map(({ text, href }, index) => (
             <li key={index}>

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,5 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit';
 
+import { isDevelopment } from '../config';
 import {
   boardsSlice,
   columnsSlice,
@@ -16,4 +17,5 @@ export const store = configureStore({
     [likesSlice.name]: likesSlice.reducer,
     [userSlice.name]: userSlice.reducer,
   },
+  devTools: isDevelopment,
 });


### PR DESCRIPTION
## What is the motivation for this pull request?

- replace menu icon with more icon in BoardControls
- Tidy Support copy
- Disable Redux devTools in production

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation