### PR TITLE
refactor(public): remove absolute url in manifest.json

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,22 +3,22 @@
   "name": "Lilboards",
   "icons": [
     {
-      "src": "https://lilboards.org/favicon.ico",
+      "src": "favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
     },
     {
-      "src": "https://lilboards.org/android-chrome-192x192.png",
+      "src": "android-chrome-192x192.png",
       "type": "image/png",
       "sizes": "192x192"
     },
     {
-      "src": "https://lilboards.org/android-chrome-512x512.png",
+      "src": "android-chrome-512x512.png",
       "type": "image/png",
       "sizes": "512x512"
     }
   ],
-  "start_url": "https://lilboards.org",
+  "start_url": ".",
   "display": "standalone",
   "theme_color": "#364fc7",
   "background_color": "#ffffff"


### PR DESCRIPTION
## What is the motivation for this pull request?

refactor(public): remove absolute url in manifest.json

## What is the current behavior?

Absolute URL in `manifest.json`

## What is the new behavior?

Relative URL in `manifest.json`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation