### PR TITLE
fix: rename `realtime` to `real-time`

### DIFF
--- a/src/components/Connection/Connection.test.tsx
+++ b/src/components/Connection/Connection.test.tsx
@@ -15,7 +15,8 @@ jest.mock('../../firebase/database', () => ({
 
 const mockedOnConnected = jest.mocked(onConnected);
 
-const message = 'Unable to connect to server. Realtime updates are paused.';
+const message =
+  'Unable to connect to the server. Real-time updates are paused.';
 
 jest.useFakeTimers();
 

--- a/src/components/Connection/Connection.tsx
+++ b/src/components/Connection/Connection.tsx
@@ -30,7 +30,7 @@ export default function Connection() {
       open={open && !connected}
     >
       <Alert onClose={handleClose} severity="error">
-        Unable to connect to server. Realtime updates are paused.
+        Unable to connect to the server. Real-time updates are paused.
       </Alert>
     </Snackbar>
   );

--- a/src/pages/Home/Features/data.tsx
+++ b/src/pages/Home/Features/data.tsx
@@ -16,7 +16,7 @@ export const features = [
   {
     icon: BoltIcon,
     heading: 'Fast',
-    description: 'Work in realtime with others—online and offline.',
+    description: 'Work in real-time with others—online and offline.',
   },
 
   {


### PR DESCRIPTION
## What is the motivation for this pull request?

fix: rename `realtime` to `real-time`

## What is the current behavior?

Copy uses `realtime`

## What is the new behavior?

Copy uses `real-time`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation