### PR TITLE
feat(Item): render links with Linkify

### DIFF
--- a/cypress/e2e/board/board.feature
+++ b/cypress/e2e/board/board.feature
@@ -14,9 +14,10 @@ Feature: Board
     When I click on button "Add column"
       And I click on button "Add item"
       And I get focused element
-      And I type "Item 1"
+      And I type "Item 1 https://example.com"
       And I blur
     Then I see text "Item 1"
+      And I see link "https://example.com"
     When I click on label "Delete column “Column 1”"
       And I click on button "Delete"
     Then I do not see text "Column 1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,8 @@
         "debounce": "2.0.0",
         "firebase": "10.7.1",
         "firebaseui": "6.1.0",
+        "linkify-react": "4.1.3",
+        "linkifyjs": "4.1.3",
         "react": "18.2.0",
         "react-beautiful-dnd": "13.1.1",
         "react-dom": "18.2.0",
@@ -13402,6 +13404,20 @@
       "dependencies": {
         "uc.micro": "^1.0.1"
       }
+    },
+    "node_modules/linkify-react": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/linkify-react/-/linkify-react-4.1.3.tgz",
+      "integrity": "sha512-rhI3zM/fxn5BfRPHfi4r9N7zgac4vOIxub1wHIWXLA5ENTMs+BGaIaFO1D1PhmxgwhIKmJz3H7uCP0Dg5JwSlA==",
+      "peerDependencies": {
+        "linkifyjs": "^4.0.0",
+        "react": ">= 15.0.0"
+      }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.1.3.tgz",
+      "integrity": "sha512-auMesunaJ8yfkHvK4gfg1K0SaKX/6Wn9g2Aac/NwX+l5VdmFZzo/hdPGxEOETj+ryRa4/fiOPjeeKURSAJx1sg=="
     },
     "node_modules/lint-staged": {
       "version": "15.2.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "debounce": "2.0.0",
     "firebase": "10.7.1",
     "firebaseui": "6.1.0",
+    "linkify-react": "4.1.3",
+    "linkifyjs": "4.1.3",
     "react": "18.2.0",
     "react-beautiful-dnd": "13.1.1",
     "react-dom": "18.2.0",

--- a/src/components/Columns/Columns.test.tsx
+++ b/src/components/Columns/Columns.test.tsx
@@ -45,7 +45,7 @@ it('uses hooks', async () => {
 it('renders item text', () => {
   const item = updateStore.withItem();
   renderWithProviders(<Columns boardId={boardId} />);
-  expect(screen.getByDisplayValue(item.text)).toBeInTheDocument();
+  expect(screen.getByText(item.text)).toBeInTheDocument();
 });
 
 it('renders liked item', () => {

--- a/src/components/Item/Item.test.tsx
+++ b/src/components/Item/Item.test.tsx
@@ -40,6 +40,18 @@ it('renders like button and count', () => {
   expect(screen.getByLabelText(/0 likes/)).toBeInTheDocument();
 });
 
+it('renders accessible textbox', () => {
+  const item = updateStore.withItem();
+  renderWithProviders(<Item {...props} itemId={item.id} />);
+  expect(screen.getByRole('textbox')).toHaveTextContent(item.text);
+});
+
+it('renders link', () => {
+  item = updateStore.withItem({ text: 'https://example.com/' });
+  renderWithProviders(<Item {...props} itemId={item.id} />);
+  expect(screen.getByRole('link')).toHaveTextContent(item.text);
+});
+
 describe('delete item', () => {
   beforeEach(() => {
     item = updateStore.withItem();
@@ -65,23 +77,31 @@ describe('edit item', () => {
     item = updateStore.withItem();
   });
 
-  it('changes item', () => {
+  it('clicks and focuses item', () => {
     renderWithProviders(<Item {...props} itemId={item.id} />);
-    const event = { target: { value: 'Item text' } };
-    const input = screen.getByLabelText(`Edit item “${item.text}”`);
-    fireEvent.change(input, event);
-    expect(screen.getByDisplayValue(event.target.value)).toBe(input);
+    const textbox = screen.getByLabelText(`Edit item “${item.text}”`);
+    fireEvent.click(textbox);
+    expect(store.getState().user.editing.itemId).toBe(itemId);
   });
 
-  it('focuses item', () => {
+  it('changes item', () => {
     renderWithProviders(<Item {...props} itemId={item.id} />);
-    fireEvent.focus(screen.getByLabelText(`Edit item “${item.text}”`));
-    expect(store.getState().user.editing.itemId).toBe(itemId);
+    const labelText = `Edit item “${item.text}”`;
+    const textbox = screen.getByLabelText(labelText);
+    fireEvent.click(textbox);
+    const textarea = screen.getByLabelText(labelText);
+    const event = { target: { value: 'Item text' } };
+    fireEvent.change(textarea, event);
+    expect(screen.getByDisplayValue(event.target.value)).toBe(textarea);
   });
 
   it('blurs item', () => {
     renderWithProviders(<Item {...props} itemId={item.id} />);
-    fireEvent.blur(screen.getByLabelText(`Edit item “${item.text}”`));
+    const labelText = `Edit item “${item.text}”`;
+    const textbox = screen.getByLabelText(labelText);
+    fireEvent.click(textbox);
+    const textarea = screen.getByLabelText(labelText);
+    fireEvent.blur(textarea);
     expect(store.getState().user.editing.itemId).toBe('');
   });
 });

--- a/src/components/Items/Items.test.tsx
+++ b/src/components/Items/Items.test.tsx
@@ -19,7 +19,7 @@ describe('add item', () => {
     const column = updateStore.withColumn();
     renderWithProviders(<Items boardId={boardId} columnId={column.id} />);
     fireEvent.click(screen.getByText('Add item'));
-    expect(screen.getByLabelText(/Edit item/)).toBeInTheDocument();
+    expect(screen.getByLabelText('Edit item “”')).toBeInTheDocument();
   });
 
   it('focuses on new item', () => {


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(Item): render links with Linkify

https://linkify.js.org/

## What is the current behavior?

Board item is a read-only, plaintext `<textarea>` when user is not editing

## What is the new behavior?

Board item is a `<div>` that uses Linkify to find and convert links to `<a>` elements. Once the `<div>` is clicked, it becomes a `<textarea>`. Once the `<textarea>` is blurred, it becomes a `<div>` again

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation