### PR TITLE
feat(pages): render back icon in breadcrumb in Board

### DIFF
--- a/src/pages/Board/Board.tsx
+++ b/src/pages/Board/Board.tsx
@@ -1,3 +1,4 @@
+import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
 import Breadcrumbs from '@mui/material/Breadcrumbs';
 import Link from '@mui/material/Link';
 import { useEffect } from 'react';
@@ -46,9 +47,11 @@ export default function Board() {
         <Link
           color="inherit"
           component={RouterLink}
+          sx={{ alignItems: 'center', display: 'flex' }}
           to="/boards"
           underline="hover"
         >
+          <ArrowBackIosIcon fontSize="inherit" />
           Boards
         </Link>
       </Breadcrumbs>


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(pages): render back icon in breadcrumb in Board

## What is the current behavior?

No icon in breadcrumb

## What is the new behavior?

Back icon in breadcrumb

![Screenshot 2024-10-26 at 3 58 00 PM](https://github.com/user-attachments/assets/91f578ca-3133-40bc-866b-518a79d8be69)

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation