### PR TITLE
feat(pages): add and show lists

### DIFF
--- a/src/components/AddList/AddList.test.tsx
+++ b/src/components/AddList/AddList.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { generateId, logEvent, saveUserListId } from 'src/firebase';
+import { DATE_NOW as dateNow, LIST_TEST_ID as listId } from 'test/constants';
+import { renderWithProviders, store, updateStore } from 'test/utils';
+
+import AddList from './AddList';
+
+jest.mock('src/firebase', () => ({
+  generateId: jest.fn(),
+  logEvent: jest.fn(),
+  saveUserListId: jest.fn(),
+}));
+
+const mockedGenerateId = jest.mocked(generateId);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedGenerateId.mockReturnValue(listId);
+});
+
+it('renders "Add list" button', () => {
+  renderWithProviders(<AddList />);
+  expect(screen.getByRole('button', { name: 'Add list' })).toBeInTheDocument();
+});
+
+it('adds new list to store and database', () => {
+  const user = updateStore.withUser();
+  renderWithProviders(<AddList />);
+  const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(dateNow);
+  fireEvent.click(screen.getByText('Add list'));
+  expect(store.getState().lists).toEqual({
+    list_test_id: {
+      createdAt: 1234567890,
+      createdBy: 'user_test_id',
+      name: '',
+    },
+  });
+  expect(saveUserListId).toBeCalledTimes(1);
+  expect(saveUserListId).toBeCalledWith(user.id, listId);
+  dateNowSpy.mockRestore();
+});
+
+it('logs add list event', () => {
+  updateStore.withUser();
+  renderWithProviders(<AddList />);
+  fireEvent.click(screen.getByText('Add list'));
+  expect(logEvent).toBeCalledTimes(1);
+  expect(logEvent).toBeCalledWith('create_list');
+});

--- a/src/components/AddList/AddList.tsx
+++ b/src/components/AddList/AddList.tsx
@@ -1,0 +1,39 @@
+import AddButton from 'src/components/AddButton';
+import { generateId, logEvent, saveUserListId } from 'src/firebase';
+import { useDispatch, useGetUserId } from 'src/hooks';
+import { actions } from 'src/store';
+import type { List } from 'src/types';
+
+export default function AddList() {
+  const dispatch = useDispatch();
+  const userId = useGetUserId();
+
+  function addList() {
+    const list: List = {
+      createdAt: Date.now(),
+      createdBy: userId,
+      name: '',
+    };
+    const listId = generateId();
+    dispatch(
+      actions.updateList({
+        list,
+        listId,
+      }),
+    );
+    dispatch(actions.setUserEditing({ listId }));
+    saveUserListId(userId, listId);
+    logEvent('create_list');
+  }
+
+  return (
+    <AddButton
+      onClick={addList}
+      size="medium"
+      sx={{ marginBottom: 2 }}
+      variant="extended"
+    >
+      Add list
+    </AddButton>
+  );
+}

--- a/src/components/AddList/index.ts
+++ b/src/components/AddList/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AddList';

--- a/src/pages/Board/Board.test.tsx
+++ b/src/pages/Board/Board.test.tsx
@@ -2,14 +2,14 @@ import { screen, waitFor } from '@testing-library/react';
 import type { DatabaseReference, DataSnapshot } from 'firebase/database';
 import { onValue } from 'firebase/database';
 import { useParams } from 'react-router-dom';
-
+import { getBoardDataRef } from 'src/firebase';
+import { Board as BoardType } from 'src/types';
 import {
   BOARD_TEST_ID as boardId,
   USER_TEST_ID as userId,
-} from '../../../test/constants';
-import { renderWithProviders, router, updateStore } from '../../../test/utils';
-import { getBoardDataRef } from '../../firebase';
-import { Board as BoardType } from '../../types';
+} from 'test/constants';
+import { renderWithProviders, router, updateStore } from 'test/utils';
+
 import Board from './Board';
 
 const mockedOnValue = jest.mocked(onValue);
@@ -21,14 +21,14 @@ jest.mock('react-router-dom', () => ({
 
 const mockedUseParams = jest.mocked(useParams);
 
-jest.mock('../../firebase', () => ({
+jest.mock('src/firebase', () => ({
   getBoardDataRef: jest.fn(),
 }));
 
 const mockedGetBoardDataRef = jest.mocked(getBoardDataRef);
 
-jest.mock('../../components/BoardControls', () => () => <p>Board Controls</p>);
-jest.mock('../../components/Columns', () => () => <p>Columns</p>);
+jest.mock('src/components/BoardControls', () => () => <p>Board Controls</p>);
+jest.mock('src/components/Columns', () => () => <p>Columns</p>);
 
 const boardControls = 'Board Controls';
 const columns = 'Columns';

--- a/src/pages/List/List.test.tsx
+++ b/src/pages/List/List.test.tsx
@@ -1,0 +1,147 @@
+import { screen, waitFor } from '@testing-library/react';
+import type { DatabaseReference, DataSnapshot } from 'firebase/database';
+import { onValue } from 'firebase/database';
+import { useParams } from 'react-router-dom';
+import { getListDataRef } from 'src/firebase';
+import { List as ListType } from 'src/types';
+import { LIST_TEST_ID as listId, USER_TEST_ID as userId } from 'test/constants';
+import { renderWithProviders, router, updateStore } from 'test/utils';
+
+import List from './List';
+
+const mockedOnValue = jest.mocked(onValue);
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: jest.fn(),
+}));
+
+const mockedUseParams = jest.mocked(useParams);
+
+jest.mock('src/firebase', () => ({
+  getListDataRef: jest.fn(),
+}));
+
+const mockedGetListDataRef = jest.mocked(getListDataRef);
+
+const unsubscribe = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('no list', () => {
+  beforeEach(() => {
+    mockedOnValue.mockImplementationOnce((query, callback) => {
+      callback({ val: () => null } as DataSnapshot);
+      return unsubscribe;
+    });
+  });
+
+  it('renders nothing when there is no list id', async () => {
+    mockedUseParams.mockReturnValue({});
+    renderWithProviders(<List />);
+    await waitFor(() => expect(screen.queryByText('Coming soon.')).toBe(null));
+  });
+
+  it('renders nothing when there is no list', async () => {
+    mockedUseParams.mockReturnValue({ listId: 'invalid' });
+    renderWithProviders(<List />);
+    await waitFor(() => expect(screen.queryByText('Coming soon.')).toBe(null));
+  });
+
+  it('redirects to "/404" when list is not found', async () => {
+    mockedUseParams.mockReturnValue({ listId: 'invalid' });
+    renderWithProviders(<List />);
+    await waitFor(() => expect(router.state.location.pathname).toBe('/404'));
+  });
+});
+
+describe('with list', () => {
+  beforeEach(() => {
+    const list = updateStore.withList();
+    mockedUseParams.mockReturnValue({ listId: list.id });
+    mockedOnValue.mockReset().mockImplementationOnce((query, callback) => {
+      callback({ val: () => list } as DataSnapshot);
+      return unsubscribe;
+    });
+  });
+
+  describe('breadcrumbs', () => {
+    it('renders lists link', () => {
+      renderWithProviders(<List />);
+      expect(screen.getByRole('link', { name: 'Lists' })).toHaveAttribute(
+        'href',
+        '/lists',
+      );
+    });
+  });
+
+  describe('list name', () => {
+    it('does not render list name as heading', () => {
+      const list = updateStore.withList({ name: '' });
+      mockedUseParams.mockReturnValue({ listId: list.id });
+      mockedOnValue.mockReset().mockImplementationOnce((query, callback) => {
+        callback({ val: () => list } as DataSnapshot);
+        return unsubscribe;
+      });
+      renderWithProviders(<List />);
+      expect(screen.getByRole('heading', { level: 1 })).toBeEmptyDOMElement();
+    });
+
+    it('renders list name as heading', () => {
+      const list = updateStore.withList();
+      mockedUseParams.mockReturnValue({ listId: list.id });
+      mockedOnValue.mockReset().mockImplementationOnce((query, callback) => {
+        callback({ val: () => list } as DataSnapshot);
+        return unsubscribe;
+      });
+      renderWithProviders(<List />);
+      expect(screen.getByRole('heading', { level: 1 })).toBe(
+        screen.getByText(list.name),
+      );
+    });
+  });
+});
+
+describe('with list and anonymous user', () => {
+  const list: ListType = {
+    createdAt: Date.now(),
+    createdBy: userId,
+    name: 'List Name',
+    updatedAt: Date.now(),
+  };
+  const listDataRef = 'listDataRef';
+
+  beforeEach(() => {
+    mockedGetListDataRef.mockReturnValueOnce(
+      listDataRef as unknown as DatabaseReference,
+    );
+    mockedOnValue.mockReset().mockImplementationOnce((query, callback) => {
+      callback({ val: (): ListType => list } as DataSnapshot);
+      return unsubscribe;
+    });
+  });
+
+  it('loads list', async () => {
+    mockedUseParams.mockReturnValue({ listId });
+    renderWithProviders(<List />);
+    const heading = await screen.findByRole('heading', {
+      level: 1,
+      name: list.name,
+    });
+    expect(heading).toBeInTheDocument();
+  });
+
+  it('attaches ref listeners', () => {
+    mockedUseParams.mockReturnValue({ listId });
+    const { unmount } = renderWithProviders(<List />);
+    expect(getListDataRef).toBeCalledTimes(1);
+    expect(getListDataRef).toBeCalledWith(listId);
+    expect(onValue).toBeCalledTimes(1);
+    expect(onValue).toBeCalledWith(listDataRef, expect.any(Function));
+
+    unmount();
+    expect(unsubscribe).toBeCalledTimes(1);
+  });
+});

--- a/src/pages/List/List.tsx
+++ b/src/pages/List/List.tsx
@@ -1,43 +1,41 @@
 import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
 import Breadcrumbs from '@mui/material/Breadcrumbs';
 import Link from '@mui/material/Link';
+import Typography from '@mui/material/Typography';
 import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Link as RouterLink } from 'react-router-dom';
-import BoardControls from 'src/components/BoardControls';
-import Columns from 'src/components/Columns';
 import { useSetDocumentTitle } from 'src/hooks';
 import type { Id } from 'src/types';
 
-import BoardName from './BoardName';
-import { useBoard } from './hooks/useBoard';
+import { useList } from './hooks/useList';
 
-export default function Board() {
-  const params = useParams<{ boardId: Id }>();
-  const boardId = params.boardId || '';
-  const { board, isLoaded } = useBoard(boardId);
-  useSetDocumentTitle(board?.name || 'Untitled Board');
+export default function List() {
+  const params = useParams<{ listId: Id }>();
+  const listId = params.listId || '';
+  const { list, isLoaded } = useList(listId);
+  useSetDocumentTitle(list?.name || 'Untitled List');
   const navigate = useNavigate();
 
   useEffect(() => {
-    // board not found
-    if (boardId && !board && isLoaded) {
+    // list not found
+    if (listId && !list && isLoaded) {
       navigate('/404');
     }
-  }, [boardId, board, isLoaded, navigate]);
+  }, [listId, list, isLoaded, navigate]);
 
-  // no board id
-  if (!boardId) {
+  // no list id
+  if (!listId) {
     return null;
   }
 
-  // board not found
-  if (boardId && !board && isLoaded) {
+  // list not found
+  if (listId && !list && isLoaded) {
     return null;
   }
 
-  // no board
-  if (!board) {
+  // no list
+  if (!list) {
     return null;
   }
 
@@ -48,19 +46,19 @@ export default function Board() {
           color="inherit"
           component={RouterLink}
           sx={{ alignItems: 'center', display: 'flex' }}
-          to="/boards"
+          to="/lists"
           underline="hover"
         >
           <ArrowBackIosIcon fontSize="inherit" />
-          Boards
+          Lists
         </Link>
       </Breadcrumbs>
 
-      {board.name ? <BoardName name={board.name} /> : <br />}
+      <Typography component="h1" gutterBottom variant="h4">
+        {list.name}
+      </Typography>
 
-      <BoardControls boardId={boardId} />
-
-      <Columns boardId={boardId} />
+      <Typography>Coming soon.</Typography>
     </>
   );
 }

--- a/src/pages/List/hooks/index.test.ts
+++ b/src/pages/List/hooks/index.test.ts
@@ -1,0 +1,5 @@
+import * as hooks from '.';
+
+it.each(['useList'] as const)('exports %s', (hookName) => {
+  expect(hooks[hookName]).toBeInstanceOf(Function);
+});

--- a/src/pages/List/hooks/index.ts
+++ b/src/pages/List/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useList';

--- a/src/pages/List/hooks/useList.ts
+++ b/src/pages/List/hooks/useList.ts
@@ -1,0 +1,60 @@
+import { onValue } from 'firebase/database';
+import { useEffect, useState } from 'react';
+import { getListDataRef } from 'src/firebase';
+import { useDispatch, useSelector } from 'src/hooks';
+import { actions } from 'src/store';
+import { Id } from 'src/types';
+
+export function useList(listId: Id) {
+  const dispatch = useDispatch();
+  const list = useSelector((state) => state.lists[listId]);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!listId) {
+      return;
+    }
+
+    // subscribe to list value
+    const unsubscribeOnValue = onValue(
+      getListDataRef(listId),
+      (listSnapshot) => {
+        const list = listSnapshot.val();
+
+        if (list) {
+          // prevent race condition with redux reducer
+          setTimeout(() => {
+            dispatch(
+              actions.loadList({
+                list,
+                listId,
+              }),
+            );
+            setIsLoaded(true);
+          });
+        } else {
+          // list removed
+          dispatch(
+            actions.deleteList({
+              listId,
+              skipSave: true,
+              userId: '',
+            }),
+          );
+          setIsLoaded(true);
+        }
+      },
+    );
+
+    // unsubscribe on unmount
+    return () => {
+      unsubscribeOnValue();
+      setIsLoaded(false);
+    };
+  }, [listId, dispatch, setIsLoaded]);
+
+  return {
+    list,
+    isLoaded,
+  };
+}

--- a/src/pages/List/index.test.tsx
+++ b/src/pages/List/index.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen, waitFor } from '@testing-library/react';
+
+import ListLoader from '.';
+
+jest.mock('./List', () => () => <>List</>);
+
+it('lazy loads List', async () => {
+  render(<ListLoader />);
+  expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+  expect(screen.getByText('List')).toBeInTheDocument();
+});

--- a/src/pages/List/index.tsx
+++ b/src/pages/List/index.tsx
@@ -1,0 +1,14 @@
+import CircularProgress from '@mui/material/CircularProgress';
+import { lazy, Suspense } from 'react';
+
+const List = lazy(() => import('./List'));
+const Connection = lazy(() => import('../../components/Connection'));
+
+export default function ListLoader() {
+  return (
+    <Suspense fallback={<CircularProgress />}>
+      <List />
+      <Connection />
+    </Suspense>
+  );
+}

--- a/src/pages/Lists/ListCard.test.tsx
+++ b/src/pages/Lists/ListCard.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { DATE_NOW as dateNow, LIST_TEST_ID as listId } from 'test/constants';
+import { renderWithProviders, store, updateStore } from 'test/utils';
+
+import ListCard from './ListCard';
+
+it('renders "Open list" link', () => {
+  const list = updateStore.withList();
+  renderWithProviders(<ListCard listId={list.id} />);
+  expect(screen.getByRole('link', { name: 'Open list' })).toHaveAttribute(
+    'href',
+    `/lists/${listId}`,
+  );
+});
+
+describe('edit list', () => {
+  let list: ReturnType<typeof updateStore.withList>;
+
+  beforeEach(() => {
+    list = updateStore.withList();
+  });
+
+  it('sets user editing listId when input is focused', () => {
+    renderWithProviders(<ListCard listId={list.id} />);
+    fireEvent.focus(screen.getByPlaceholderText('Untitled List'));
+    expect(store.getState().user.editing.listId).toBe(list.id);
+  });
+
+  it('edits and saves list name on change', async () => {
+    updateStore.withUser();
+    renderWithProviders(<ListCard listId={list.id} />);
+    const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(dateNow);
+    const event = { target: { value: 'My List Name' } };
+    fireEvent.change(screen.getByLabelText('List Name'), event);
+    expect(store.getState().lists).toEqual({
+      list_test_id: {
+        createdAt: 1234567890,
+        createdBy: 'user_test_id',
+        name: 'My List Name',
+        updatedAt: 1234567890,
+        updatedBy: 'user_test_id',
+      },
+    });
+    dateNowSpy.mockRestore();
+  });
+
+  it('resets user editing listId on blur', () => {
+    renderWithProviders(<ListCard listId={list.id} />);
+    fireEvent.blur(screen.getByLabelText('List Name'));
+    expect(store.getState().user.editing.listId).toBe('');
+  });
+});
+
+describe('delete list', () => {
+  let list: ReturnType<typeof updateStore.withList>;
+  const dialogContent = 'This action cannot be undone.';
+
+  beforeEach(() => {
+    list = updateStore.withList();
+    updateStore.withUser();
+  });
+
+  it('renders dialog with name', () => {
+    renderWithProviders(<ListCard listId={list.id} />);
+    fireEvent.click(screen.getByLabelText(`Delete list “${list.name}”`));
+    expect(screen.getByText(`Delete list “${list.name}”?`)).toBeInTheDocument();
+    expect(screen.getByText(dialogContent)).toBeInTheDocument();
+  });
+
+  it('renders dialog with no name', () => {
+    list = updateStore.withList({ name: '' });
+    updateStore.withUser();
+    renderWithProviders(<ListCard listId={list.id} />);
+    fireEvent.click(screen.getByLabelText('Delete list'));
+    expect(screen.getByText('Delete list?')).toBeInTheDocument();
+    expect(screen.getByText(dialogContent)).toBeInTheDocument();
+  });
+
+  it('cancels delete', () => {
+    renderWithProviders(<ListCard listId={list.id} />);
+    fireEvent.click(screen.getByLabelText(/Delete list/));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByText(dialogContent)).not.toBeVisible();
+    expect(screen.getByDisplayValue(list.name)).toBeInTheDocument();
+  });
+
+  it('deletes list', () => {
+    renderWithProviders(<ListCard listId={list.id} />);
+    fireEvent.click(screen.getByLabelText(/Delete list/));
+    fireEvent.click(screen.getAllByText('Delete')[1]);
+    expect(screen.queryByText(dialogContent)).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue(list.name)).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/Lists/ListCard.tsx
+++ b/src/pages/Lists/ListCard.tsx
@@ -1,0 +1,124 @@
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardActions from '@mui/material/CardActions';
+import CardContent from '@mui/material/CardContent';
+import Grid from '@mui/material/Grid';
+import TextField from '@mui/material/TextField';
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import DeleteDialog from 'src/components/DeleteDialog';
+import { logEvent } from 'src/firebase';
+import { useDispatch, useGetUserId, useSelector } from 'src/hooks';
+import { actions } from 'src/store';
+import type { Id } from 'src/types';
+
+interface Props {
+  listId: Id;
+}
+
+export default function ListCard(props: Props) {
+  const dispatch = useDispatch();
+  const list = useSelector((state) => state.lists[props.listId]);
+  const isEditing = useSelector(
+    (state) => state.user.editing.listId === props.listId,
+  );
+  const userId = useGetUserId();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  if (!list) {
+    return null;
+  }
+
+  function handleChange(
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) {
+    dispatch(
+      actions.updateList({
+        list: {
+          name: event.target.value,
+          updatedAt: Date.now(),
+          updatedBy: userId,
+        },
+        listId: props.listId,
+        debounce: true,
+      }),
+    );
+  }
+
+  function handleBlur() {
+    dispatch(actions.setUserEditing({ listId: '' }));
+  }
+
+  function handleFocus() {
+    dispatch(actions.setUserEditing({ listId: props.listId }));
+  }
+
+  function deleteList() {
+    dispatch(
+      actions.deleteList({
+        listId: props.listId,
+        userId,
+      }),
+    );
+    logEvent('delete_list');
+  }
+
+  return (
+    <Grid item xs={12} sm={6} md={3}>
+      <Card raised={isEditing}>
+        <CardContent sx={{ paddingBottom: 0 }}>
+          <TextField
+            autoFocus={isEditing}
+            fullWidth
+            id={props.listId}
+            label="List Name"
+            placeholder="Untitled List"
+            onBlur={handleBlur}
+            onChange={handleChange}
+            onFocus={handleFocus}
+            value={list.name}
+          />
+        </CardContent>
+
+        <CardActions
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            marginLeft: 1,
+            marginRight: 1,
+          }}
+        >
+          <Button
+            aria-label="Open list"
+            component={Link}
+            to={`/lists/${props.listId}`}
+          >
+            Open
+          </Button>
+
+          <Button
+            aria-label={
+              list.name ? `Delete list “${list.name}”` : 'Delete list'
+            }
+            color="error"
+            onClick={() => setIsDialogOpen(true)}
+          >
+            Delete
+          </Button>
+
+          <DeleteDialog
+            content="This action cannot be undone."
+            id={props.listId}
+            onClose={() => setIsDialogOpen(false)}
+            onDelete={() => {
+              deleteList();
+              setIsDialogOpen(false);
+            }}
+            open={isDialogOpen}
+            title={list.name ? `Delete list “${list.name}”?` : 'Delete list?'}
+          />
+        </CardActions>
+      </Card>
+    </Grid>
+  );
+}

--- a/src/pages/Lists/ListCards.test.tsx
+++ b/src/pages/Lists/ListCards.test.tsx
@@ -1,0 +1,23 @@
+import { screen } from '@testing-library/react';
+import { renderWithProviders, updateStore } from 'test/utils';
+
+import ListCards from './ListCards';
+
+jest.mock('src/firebase', () => ({
+  ...jest.requireActual('src/firebase'),
+  getListVal: jest.fn(),
+  getUserListsVal: jest.fn(),
+}));
+
+it('renders nothing when there are no boards', () => {
+  renderWithProviders(<ListCards />);
+  expect(screen.queryByLabelText('List Name')).not.toBeInTheDocument();
+});
+
+it('renders ListCard', () => {
+  const board = updateStore.withList();
+  renderWithProviders(<ListCards />);
+  expect(screen.getByDisplayValue(board.name)).toBe(
+    screen.getByLabelText('List Name'),
+  );
+});

--- a/src/pages/Lists/ListCards.tsx
+++ b/src/pages/Lists/ListCards.tsx
@@ -1,0 +1,23 @@
+import Grid from '@mui/material/Grid';
+import { useSelector } from 'src/hooks';
+
+import { useLists } from './hooks';
+import ListCard from './ListCard';
+import { selectListIds } from './selectors';
+
+export default function ListCards() {
+  useLists();
+  const listIds = useSelector(selectListIds);
+
+  if (!listIds.length) {
+    return null;
+  }
+
+  return (
+    <Grid container spacing={2}>
+      {listIds.map((listId) => (
+        <ListCard listId={listId} key={listId} />
+      ))}
+    </Grid>
+  );
+}

--- a/src/pages/Lists/Lists.test.tsx
+++ b/src/pages/Lists/Lists.test.tsx
@@ -1,10 +1,83 @@
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
+import { getListVal, getUserListsVal } from 'src/firebase';
+import { List } from 'src/types';
+import { LIST_TEST_ID as listId } from 'test/constants';
+import { renderWithProviders, updateStore } from 'test/utils';
 
-import { renderWithProviders } from '../../../test/utils';
 import Lists from './Lists';
+
+jest.mock('src/firebase', () => ({
+  ...jest.requireActual('src/firebase'),
+  getListVal: jest.fn(),
+  getUserListsVal: jest.fn(),
+  logEvent: jest.fn(),
+}));
+
+const mockedGetListVal = jest.mocked(getListVal);
+const mockedGetUserListsVal = jest.mocked(getUserListsVal);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedGetListVal.mockResolvedValueOnce(null);
+  mockedGetUserListsVal.mockResolvedValueOnce(null);
+});
 
 it('renders heading', () => {
   renderWithProviders(<Lists />);
   const heading = screen.getByRole('heading', { level: 1, name: 'Lists' });
   expect(heading).toBeInTheDocument();
+});
+
+describe('add list', () => {
+  it('renders button', () => {
+    renderWithProviders(<Lists />);
+    expect(
+      screen.getByRole('button', { name: 'Add list' }),
+    ).toBeInTheDocument();
+  });
+
+  it('adds list', () => {
+    updateStore.withUser();
+    renderWithProviders(<Lists />);
+    fireEvent.click(screen.getByText('Add list'));
+    expect(screen.getAllByLabelText('List Name')).toHaveLength(1);
+  });
+
+  it('adds lists', () => {
+    updateStore.withUser();
+    renderWithProviders(<Lists />);
+    const length = 2;
+    Array.from({ length }, () => fireEvent.click(screen.getByText('Add list')));
+    expect(screen.getAllByLabelText('List Name')).toHaveLength(length);
+  });
+
+  it('focuses on list', () => {
+    updateStore.withUser();
+    renderWithProviders(<Lists />);
+    fireEvent.click(screen.getByText('Add list'));
+    expect(screen.getByPlaceholderText('Untitled List')).toHaveFocus();
+  });
+});
+
+describe('mount', () => {
+  beforeEach(() => {
+    mockedGetUserListsVal.mockReset().mockResolvedValueOnce({
+      [`${listId}1`]: true,
+      [`${listId}2`]: true,
+      [`${listId}3`]: false,
+    });
+
+    mockedGetListVal
+      .mockReset()
+      .mockResolvedValueOnce({ name: 'List 1' } as List)
+      .mockResolvedValueOnce({ name: 'List 2' } as List)
+      .mockResolvedValueOnce(null);
+  });
+
+  it('loads lists', async () => {
+    updateStore.withUser();
+    renderWithProviders(<Lists />);
+    const lists = await screen.findAllByLabelText('List Name');
+    expect(lists).toHaveLength(2);
+  });
 });

--- a/src/pages/Lists/Lists.tsx
+++ b/src/pages/Lists/Lists.tsx
@@ -1,6 +1,8 @@
 import Typography from '@mui/material/Typography';
+import AddList from 'src/components/AddList';
+import { useSetDocumentTitle } from 'src/hooks';
 
-import { useSetDocumentTitle } from '../../hooks';
+import ListCards from './ListCards';
 
 export default function Lists() {
   useSetDocumentTitle('Lists');
@@ -11,7 +13,9 @@ export default function Lists() {
         Lists
       </Typography>
 
-      <Typography>Coming soon.</Typography>
+      <AddList />
+
+      <ListCards />
     </>
   );
 }

--- a/src/pages/Lists/hooks/index.ts
+++ b/src/pages/Lists/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useLists';

--- a/src/pages/Lists/hooks/useLists.ts
+++ b/src/pages/Lists/hooks/useLists.ts
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+import { getListVal, getUserListsVal } from 'src/firebase';
+import { useDispatch, useGetUserId } from 'src/hooks';
+import { actions } from 'src/store';
+
+export function useLists() {
+  const dispatch = useDispatch();
+  const userId = useGetUserId();
+
+  useEffect(() => {
+    (async () => {
+      const userLists = await getUserListsVal(userId);
+
+      if (!userLists) {
+        return;
+      }
+
+      const listIds = Object.keys(userLists);
+
+      const lists = await Promise.all(
+        listIds.map(async (listId) => {
+          const list = await getListVal(listId);
+
+          if (list) {
+            return {
+              list,
+              listId,
+            };
+          }
+        }),
+      );
+
+      lists.forEach((list) => list && dispatch(actions.loadList(list)));
+    })();
+  }, [dispatch, userId]);
+}

--- a/src/pages/Lists/selectors/index.ts
+++ b/src/pages/Lists/selectors/index.ts
@@ -1,0 +1,1 @@
+export * from './lists';

--- a/src/pages/Lists/selectors/lists.ts
+++ b/src/pages/Lists/selectors/lists.ts
@@ -1,0 +1,17 @@
+import { createSelector } from '@reduxjs/toolkit';
+import { RootState, SortBy, SortOrder } from 'src/types';
+import { sort } from 'src/utils';
+
+export const selectListIds = createSelector(
+  (state: RootState) => state.lists,
+  (lists) => {
+    const listsWithId = Object.keys(lists).map((id) => ({
+      ...lists[id],
+      id,
+    }));
+
+    return sort(listsWithId, SortBy.createdAt, SortOrder.Descending).map(
+      (list) => list.id,
+    );
+  },
+);

--- a/src/routes/__snapshots__/routes.test.tsx.snap
+++ b/src/routes/__snapshots__/routes.test.tsx.snap
@@ -68,6 +68,19 @@ exports[`matches snapshot 1`] = `
           index={true}
         />
       </Route>
+      <Route
+        element={
+          <ProtectedLoader
+            check="id"
+            signInAnonymously={true}
+          />
+        }
+      >
+        <Route
+          element={<ListLoader />}
+          path=":listId"
+        />
+      </Route>
     </Route>
     <Route
       element={<NotFoundLoader />}

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -1,16 +1,16 @@
 import { Route } from 'react-router-dom';
-
-import Layout from '../components/Layout';
-import Protected from '../components/Protected';
-import Board from '../pages/Board';
-import Boards from '../pages/Boards';
-import ErrorBoundary from '../pages/ErrorBoundary';
-import Home from '../pages/Home';
-import Lists from '../pages/Lists';
-import Login from '../pages/Login';
-import Logout from '../pages/Logout';
-import NotFound from '../pages/NotFound';
-import Support from '../pages/Support';
+import Layout from 'src/components/Layout';
+import Protected from 'src/components/Protected';
+import Board from 'src/pages/Board';
+import Boards from 'src/pages/Boards';
+import ErrorBoundary from 'src/pages/ErrorBoundary';
+import Home from 'src/pages/Home';
+import List from 'src/pages/List';
+import Lists from 'src/pages/Lists';
+import Login from 'src/pages/Login';
+import Logout from 'src/pages/Logout';
+import NotFound from 'src/pages/NotFound';
+import Support from 'src/pages/Support';
 
 const routes = (
   <Route path="/" element={<Layout />}>
@@ -34,6 +34,10 @@ const routes = (
       <Route path="lists">
         <Route element={<Protected check="email" />}>
           <Route index element={<Lists />} />
+        </Route>
+
+        <Route element={<Protected check="id" signInAnonymously />}>
+          <Route path=":listId" element={<List />} />
         </Route>
       </Route>
 

--- a/test/utils.tsx
+++ b/test/utils.tsx
@@ -4,13 +4,14 @@ import { Provider } from 'react-redux';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 import { DatabaseKey } from 'src/constants';
 import { actions, resetActions, store } from 'src/store';
-import type { Board, Columns, Item, User } from 'src/types';
+import type { Board, Columns, Item, List, User } from 'src/types';
 
 import {
   BOARD_TEST_ID as boardId,
   COLUMN_TEST_ID as columnId,
   DATE_NOW as dateNow,
   ITEM_TEST_ID as itemId,
+  LIST_TEST_ID as listId,
   USER_TEST_EMAIL as userEmail,
   USER_TEST_ID as userId,
 } from './constants';
@@ -133,6 +134,23 @@ export const updateStore = {
       userId,
     };
     store.dispatch(actions.likeItem(payload));
+  },
+
+  withList(list?: Partial<List>) {
+    const payload = {
+      list: {
+        createdAt: dateNow,
+        createdBy: userId,
+        name: 'List One',
+        ...list,
+      },
+      listId,
+    };
+    store.dispatch(actions.loadList(payload));
+    return {
+      ...payload.list,
+      id: listId,
+    };
   },
 
   withUser(email = true, override?: Partial<User>) {


### PR DESCRIPTION
## What is the motivation for this pull request?

- Add and show lists
- Render placeholder list page

![Screenshot 2024-10-27 at 1 33 40 PM](https://github.com/user-attachments/assets/021be98b-aabe-45ef-8796-0732ce70d276)
![Screenshot 2024-10-27 at 1 33 48 PM](https://github.com/user-attachments/assets/12e50c4b-b632-4825-8bd8-e826625d6f33)

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation