### PR TITLE
feat(pages): render breadcrumb in Board and List when logged in

### DIFF
--- a/src/pages/Board/Board.test.tsx
+++ b/src/pages/Board/Board.test.tsx
@@ -75,7 +75,15 @@ describe('with board', () => {
   });
 
   describe('breadcrumbs', () => {
-    it('renders boards link', () => {
+    it('does not render link when logged out', () => {
+      renderWithProviders(<Board />);
+      expect(
+        screen.queryByRole('link', { name: 'Boards' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders link when logged in', () => {
+      updateStore.withUser();
       renderWithProviders(<Board />);
       expect(screen.getByRole('link', { name: 'Boards' })).toHaveAttribute(
         'href',

--- a/src/pages/Board/Board.tsx
+++ b/src/pages/Board/Board.tsx
@@ -3,7 +3,7 @@ import BoardControls from 'src/components/BoardControls';
 import Breadcrumb from 'src/components/Breadcrumb';
 import Columns from 'src/components/Columns';
 import Heading from 'src/components/Heading';
-import { useSetDocumentTitle } from 'src/hooks';
+import { useIsLoggedIn, useSetDocumentTitle } from 'src/hooks';
 import type { Id } from 'src/types';
 
 import { useBoard } from './hooks/useBoard';
@@ -13,6 +13,7 @@ export default function Board() {
   const boardId = params.boardId || '';
   const board = useBoard(boardId);
   useSetDocumentTitle(board?.name || 'Untitled Board');
+  const isLoggedIn = useIsLoggedIn();
 
   if (!boardId || !board) {
     return null;
@@ -20,7 +21,7 @@ export default function Board() {
 
   return (
     <>
-      <Breadcrumb to="/boards">Boards</Breadcrumb>
+      {isLoggedIn && <Breadcrumb to="/boards">Boards</Breadcrumb>}
 
       <Heading link>{board.name}</Heading>
 

--- a/src/pages/List/List.test.tsx
+++ b/src/pages/List/List.test.tsx
@@ -68,7 +68,15 @@ describe('with list', () => {
   });
 
   describe('breadcrumbs', () => {
-    it('renders lists link', () => {
+    it('does not render link when logged out', () => {
+      renderWithProviders(<List />);
+      expect(
+        screen.queryByRole('link', { name: 'Lists' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders link when logged in', () => {
+      updateStore.withUser();
       renderWithProviders(<List />);
       expect(screen.getByRole('link', { name: 'Lists' })).toHaveAttribute(
         'href',

--- a/src/pages/List/List.tsx
+++ b/src/pages/List/List.tsx
@@ -2,7 +2,7 @@ import Typography from '@mui/material/Typography';
 import { useParams } from 'react-router-dom';
 import Breadcrumb from 'src/components/Breadcrumb';
 import Heading from 'src/components/Heading';
-import { useSetDocumentTitle } from 'src/hooks';
+import { useIsLoggedIn, useSetDocumentTitle } from 'src/hooks';
 import type { Id } from 'src/types';
 
 import { useList } from './hooks/useList';
@@ -12,6 +12,7 @@ export default function List() {
   const listId = params.listId || '';
   const list = useList(listId);
   useSetDocumentTitle(list?.name || 'Untitled List');
+  const isLoggedIn = useIsLoggedIn();
 
   if (!listId || !list) {
     return null;
@@ -19,7 +20,7 @@ export default function List() {
 
   return (
     <>
-      <Breadcrumb to="/lists">Lists</Breadcrumb>
+      {isLoggedIn && <Breadcrumb to="/lists">Lists</Breadcrumb>}
 
       <Heading link>{list.name}</Heading>
 


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(pages): render breadcrumb in Board and List when logged in

## What is the current behavior?

Breadcrumb is rendered in Board/List when logged out

## What is the new behavior?

Breadcrumb is not rendered in Board/List when logged out

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation