### PR TITLE
feat(pages): navigate to board on submit in BoardCard

### DIFF
--- a/cypress/e2e/boards/boards.feature
+++ b/cypress/e2e/boards/boards.feature
@@ -7,13 +7,21 @@ Feature: Boards
       And I see heading "Boards"
       And I see button "Add board"
     When I click on button "Add board"
-      And I get focused element
-      And I type "My Board 1"
-    Then I see text "Board Name"
+    Then I see label "Board Name"
+    When I get focused element
+      And I type "Board 1"
+      And I wait 300 milliseconds
+      And I type "{enter}"
+    Then I see URL contains "/boards/"
+      And I see heading "Board 1"
+    When I go back
+    Then I see URL "/boards"
       And I see link "Open"
       And I see button "Delete"
     When I click on button "Add board"
-      And I click on button "Delete"
+      And I find links by text "Open"
+    Then I count 2 elements
+    When I click on button "Delete"
     Then I see text "Delete board?"
       And I see text "This action cannot be undone."
     When I find buttons by text "Delete"
@@ -22,6 +30,6 @@ Feature: Boards
       And I find links by text "Open"
     Then I count 1 element
     When I click on button "Delete"
-    Then I see text "Delete board “My Board 1”?"
+    Then I see text "Delete board “Board 1”?"
     When I click on button "Cancel"
-    Then I see text "My Board 1"
+    Then I see text "Board 1"

--- a/src/pages/Boards/BoardCard.test.tsx
+++ b/src/pages/Boards/BoardCard.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, screen } from '@testing-library/react';
 import { boardId, dateNow } from 'test/constants';
-import { renderWithProviders, store, updateStore } from 'test/utils';
+import { renderWithProviders, router, store, updateStore } from 'test/utils';
 
 import BoardCard from './BoardCard';
 
@@ -11,7 +11,7 @@ describe('open board', () => {
     board = updateStore.withBoard();
   });
 
-  it('renders "Open board" link', () => {
+  it('renders link to open board', () => {
     renderWithProviders(<BoardCard boardId={board.id} />);
     expect(screen.getByRole('link', { name: 'Open board' })).toHaveAttribute(
       'href',
@@ -19,9 +19,10 @@ describe('open board', () => {
     );
   });
 
-  it('handles submit', () => {
+  it('navigates to board on submit', () => {
     renderWithProviders(<BoardCard boardId={board.id} />);
     fireEvent.submit(screen.getByRole('form', { name: '' }));
+    expect(router.state.location.pathname).toBe(`/boards/${board.id}`);
   });
 });
 

--- a/src/pages/Boards/BoardCard.tsx
+++ b/src/pages/Boards/BoardCard.tsx
@@ -6,6 +6,7 @@ import Grid from '@mui/material/Grid';
 import TextField from '@mui/material/TextField';
 import { useCallback, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import DeleteDialog from 'src/components/DeleteDialog';
 import { DatabaseKey } from 'src/constants';
 import { logEvent } from 'src/firebase';
@@ -30,6 +31,8 @@ export default function BoardCard(props: Props) {
   );
   const userId = useGetUserId();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const navigate = useNavigate();
+  const boardUrl = `/boards/${props.boardId}`;
 
   const handleChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -69,8 +72,9 @@ export default function BoardCard(props: Props) {
   const handleSubmit = useCallback(
     (event: React.FormEvent<HTMLFormElement>) => {
       event.preventDefault();
+      navigate(boardUrl);
     },
-    [],
+    [boardUrl, navigate],
   );
 
   if (!board) {
@@ -107,11 +111,7 @@ export default function BoardCard(props: Props) {
             marginRight: 1,
           }}
         >
-          <Button
-            aria-label="Open board"
-            component={Link}
-            to={`/boards/${props.boardId}`}
-          >
+          <Button aria-label="Open board" component={Link} to={boardUrl}>
             Open
           </Button>
 


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(pages): navigate to board on submit in BoardCard

## What is the current behavior?

To open board, you need to click on the "Open" button link

## What is the new behavior?

Hitting "Enter" will navigate to the board

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation